### PR TITLE
Add naive bayes categorizer and UI components

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "bayes": "^0.0.7",
     "bootstrap": "^4.0.0",
     "d3-array": "^1.2.1",
     "d3-collection": "^1.0.4",
@@ -17,7 +18,8 @@
     "recharts": "^1.0.0-beta.10",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "uuid": "^3.2.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,8 @@ export const SAVE_TRANSACTIONS = 'SAVE_TRANSACTIONS';
 export const CANCEL_TRANSACTIONS = 'CANCEL_TRANSACTIONS';
 export const UPDATE_SKIP_ROWS = 'UPDATE_SKIP_ROWS';
 export const UPDATE_COLUMN_TYPE = 'UPDATE_COLUMN_TYPE';
+export const GUESS_CATEGORY_FOR_ROW = 'GUESS_CATEGORY_FOR_ROW';
+export const CATEGORIZE_ROW = 'CATEGORIZE_ROW';
 
 export const parseTransactionsStart = () => {
   return {
@@ -42,5 +44,20 @@ export const saveTransactions = () => {
 export const cancelTransactions = () => {
   return {
     type: CANCEL_TRANSACTIONS
+  };
+};
+
+export const guessCategoryForRow = rowId => {
+  return {
+    type: GUESS_CATEGORY_FOR_ROW,
+    rowId
+  };
+};
+
+export const categorizeRow = (rowId, category) => {
+  return {
+    type: CATEGORIZE_ROW,
+    rowId,
+    category
   };
 };

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import Intro from './Intro';
 import Menu from './Menu';
 import TransactionUpload from './TransactionUpload';
 import Chart from './Chart';
+import Transactions from './Transactions';
 
 const App = props => {
   return (
@@ -14,6 +15,7 @@ const App = props => {
           <Route exact path="/" component={Intro} />
           <Route exact path="/upload" component={TransactionUpload} />
           <Route exact path="/chart" component={Chart} />
+          <Route exact path="/transaction" component={Transactions} />
         </div>
       </React.Fragment>
     </Router>

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -8,7 +8,7 @@ const Intro = props => {
       <p className="lead">Privacy-First Bank Transaction Analysis</p>
       <hr />
       <p>
-        Catchy headline eh? But seriously, if you bave a list of bank transactions, and you want to see some pretty graphs, go ahead and upload the file here. It will never be stored anywhere.
+        Catchy headline eh? But seriously, if you have a list of bank transactions, and you want to see some pretty graphs, go ahead and upload the file here. It will never be stored anywhere.
       </p>
       <Link className="btn btn-dark btn-lg" to="/upload">Get Started</Link>
     </div>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -21,6 +21,9 @@ const Menu = props => {
             <li className={`nav-item${active('/chart')}`}>
               <Link className="nav-link" to="/chart">Charts</Link>
             </li>
+            <li className={`nav-item${active('/transaction')}`}>
+              <Link className="nav-link" to="/transaction">Transactions</Link>
+            </li>
           </ul>
         </div>
       </div>

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import * as actions from '../actions';
+
+// XXX: This is not nice :-)
+const categories = [
+  { key: 'food', name: 'Food' },
+  { key: 'travel', name: 'Travel' }
+];
+
+const CategoryGuess = props => {
+  if (props.transaction.category.guess) return props.transaction.category.guess;
+  // XXX: Should probably not be a manual process, but it works for now.
+  return (
+    <button
+      type="button"
+      onClick={() => props.handleGuessCategoryForRow(props.transaction.id)}
+    >
+      Guess!
+    </button>
+  )
+};
+
+const CategorySelect = props => {
+  return (
+    <select
+      className="form-control"
+      onChange={e => props.handleRowCategory(props.transaction.id, e.target.value)}
+    >
+      <option value=""></option>
+      {categories.map(category => {
+        return <option
+          key={`cat-${props.transaction.id}-${category.key}`}
+          value={category.key}
+        >
+          {category.name}
+        </option>
+      })}
+    </select>
+  );
+};
+
+CategorySelect.propTypes = {
+  handleRowCategory: PropTypes.func.isRequired
+};
+
+const RowCategorizer = props => {
+  if (props.transaction.category.confirmed) return props.transaction.category.confirmed;
+  return (
+    <React.Fragment>
+      <CategoryGuess {...props} />
+      <CategorySelect {...props} />
+    </React.Fragment>
+  );
+};
+
+const TransactionRow = props => {
+  return (
+    <tr>
+      <td>
+        {props.transaction.date}
+      </td>
+      <td>
+        {props.transaction.description}
+      </td>
+      <td>
+        {props.transaction.amount}
+      </td>
+      <td>
+        {props.transaction.total}
+      </td>
+      <td>
+        <RowCategorizer {...props} />
+      </td>
+    </tr>
+  );
+};
+
+TransactionRow.propTypes = {
+  transaction: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired
+}
+
+const TransactionTable = props => {
+  const data = props.transactions;
+
+  return (
+    <div className="row justify-content-center">
+      <div className="col">
+        <table className="table table-striped">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Description</th>
+              <th>Amount</th>
+              <th>Total</th>
+              <th>Category</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((transaction, i) => {
+              return <TransactionRow
+                key={`row-${transaction.id}`}
+                transaction={transaction}
+                handleRowCategory={props.handleRowCategory}
+                handleGuessCategoryForRow={props.handleGuessCategoryForRow}
+              />
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+const Transactions = props => {
+  return (
+    <TransactionTable
+      transactions={props.transactions}
+      handleRowCategory={props.handleRowCategory}
+      handleGuessCategoryForRow={props.handleGuessCategoryForRow}
+    />
+  );
+};
+
+Transactions.propTypes = {
+  transactions: PropTypes.arrayOf(PropTypes.object).isRequired
+}
+
+const mapStateToProps = state => {
+  return {
+    transactions: state.transactions.data,
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    handleRowCategory: (rowId, category) => {
+      dispatch(actions.categorizeRow(rowId, category));
+    },
+    handleGuessCategoryForRow: rowId => {
+      dispatch(actions.guessCategoryForRow(rowId));
+    }
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Transactions)

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,30 @@
+import moment from 'moment';
+
+/**
+ * Given a list of transactions (an array of arrays), guess which column
+ * correspond to date, descriptions, etc.
+ * @param {Array} transactions - A list of transactions
+ */
+export const guessColumnSpec = transactions => {
+  // Take the last transaction for now since there might be headers at the top.
+  const transaction = transactions[transactions.length - 1];
+  const columnSpec = transaction.map(t => ({ type: '' }));
+
+  const hasColumnType = columnType => columnSpec.some(c => c.type === columnType);
+
+  for (let i = 0; i < transaction.length; i++) {
+    const val = transaction[i];
+    // If the type is a string, use it as date or description.
+    // If the type is a number, use as amount or total, depending on whether we
+    // found one of these already.
+    if (typeof val === 'string') {
+      if (!hasColumnType('date') && moment(val).isValid()) columnSpec[i].type = 'date';
+      else if (!hasColumnType('description')) columnSpec[i].type = 'description';
+    } else if (typeof val === 'number') {
+      if (!hasColumnType('amount')) columnSpec[i].type = 'amount';
+      else columnSpec[i].type = 'total';
+    }
+  }
+
+  return columnSpec;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,6 +1022,10 @@ batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
 
+bayes@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/bayes/-/bayes-0.0.7.tgz#357bf74aa887e796de4bf5e922c5631090af8a00"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -7320,7 +7324,7 @@ uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
This commit adds a naive bayes classifier for guessing categories as
well as a simple UI for adding the categories.

Changes:
- Add bayes library
- Add functionality for manually categorizing a row (for training)
- Add functionality for guessing a row's category.

Limitations:
- The UI is not nice
- There are only two hardcoded categories currently.

Fix:
- Typo on frontpage