### PR TITLE
Add download/restore functionality and UI updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome": "^1.1.5",
+    "@fortawesome/fontawesome-free-solid": "^5.0.10",
+    "@fortawesome/react-fontawesome": "^0.0.18",
     "bayes": "^0.0.7",
     "bootstrap": "^4.0.0",
     "d3-array": "^1.2.1",
     "d3-collection": "^1.0.4",
+    "downloadjs": "^1.4.7",
     "immutability-helper": "^2.6.6",
     "moment": "^2.22.0",
     "papaparse": "^4.3.7",
@@ -18,6 +22,7 @@
     "recharts": "^1.0.0-beta.10",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
+    "redux-modal": "^1.7.3",
     "redux-persist": "^5.9.1",
     "redux-thunk": "^2.2.0",
     "uuid": "^3.2.1"

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,6 +7,7 @@ export const UPDATE_SKIP_ROWS = 'UPDATE_SKIP_ROWS';
 export const UPDATE_COLUMN_TYPE = 'UPDATE_COLUMN_TYPE';
 export const GUESS_CATEGORY_FOR_ROW = 'GUESS_CATEGORY_FOR_ROW';
 export const CATEGORIZE_ROW = 'CATEGORIZE_ROW';
+export const RESTORE_STATE_FROM_FILE = 'RESTORE_STATE_FROM_FILE';
 
 export const parseTransactionsStart = () => {
   return {
@@ -67,5 +68,12 @@ export const categorizeRow = (rowId, category) => {
     type: CATEGORIZE_ROW,
     rowId,
     category
+  };
+};
+
+export const restoreStateFromFile = newState => {
+  return {
+    type: RESTORE_STATE_FROM_FILE,
+    newState
   };
 };

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,6 +5,7 @@ import Menu from './Menu';
 import TransactionUpload from './TransactionUpload';
 import Chart from './Chart';
 import Transactions from './Transactions';
+import Data from './Data';
 
 const App = props => {
   return (
@@ -13,9 +14,10 @@ const App = props => {
         <Route path="/*" render={routeProps => <Menu persistor={props.persistor} {...routeProps} />} />
         <div className="container mt-4">
           <Route exact path="/" component={Intro} />
-          <Route exact path="/upload" component={TransactionUpload} />
           <Route exact path="/chart" component={Chart} />
           <Route exact path="/transaction" component={Transactions} />
+          <Route exact path="/transaction/upload" component={TransactionUpload} />
+          <Route exact path="/data" component={Data} />
         </div>
       </React.Fragment>
     </Router>

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -11,6 +11,7 @@ import {
 } from 'recharts';
 import { nest } from 'd3-collection';
 import { sum } from 'd3-array';
+import NoData from './NoData';
 
 // Bootstrap colors
 // TODO: Should probably find a better way to store these.
@@ -65,7 +66,7 @@ const AmountPerCategory = props => {
 };
 
 const Chart = props => {
-  if (props.transactions.data.length === 0) return null;
+  if (props.transactions.data.length === 0) return <NoData />;
 
   return (
     <div className="row justify-content-center">

--- a/src/components/Chart.test.js
+++ b/src/components/Chart.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
+import { MemoryRouter } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 import Chart from './Chart';
 
@@ -13,8 +14,12 @@ describe('Chart', () => {
       }
     });
 
-    const container = shallow(<Chart store={store} />);
-    expect(container.render().html()).toEqual(null);
+    const container = shallow(
+      <MemoryRouter>
+        <Chart store={store} />
+      </MemoryRouter>
+    );
+    expect(container.render().text()).toEqual('No data yet. Add some.');
   });
 
   it('should render transactions graph when there are transactions', () => {

--- a/src/components/Data.js
+++ b/src/components/Data.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import download from 'downloadjs';
+import * as actions from '../actions';
+
+class Data extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleDownload = this.handleDownload.bind(this);
+    this.handleRestoreFile = this.handleRestoreFile.bind(this);
+    this.handleRestoreClick = this.handleRestoreClick.bind(this);
+  }
+
+  handleDownload() {
+    const blob = new Blob([JSON.stringify(this.props.state)], {
+      type: 'application/json'
+    });
+    download(blob, 'data.json', 'application/json');
+  }
+
+  handleRestoreFile(e) {
+    const reader = new FileReader();
+
+    reader.onload = fe => {
+      const newState = JSON.parse(fe.target.result);
+      this.props.restoreStateFromFile(newState);
+    };
+
+    reader.readAsText(e.target.files[0], 'utf-8');
+  }
+
+  handleRestoreClick() {
+    this.fileInput.click();
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <div className="row">
+          <div className="col-auto">
+            <dl>
+              <dt>Number of transactions</dt>
+              <dd>{this.props.numTransactions}</dd>
+            </dl>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-auto">
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={this.handleDownload}
+            >
+              Download All Data
+            </button>
+            <input
+              ref={ref => this.fileInput = ref}
+              type="file"
+              style={{ display: 'none' }}
+              onChange={this.handleRestoreFile}
+            />
+            <button
+              type="button"
+              className="btn btn-outline-secondary ml-3"
+              onClick={this.handleRestoreClick}
+            >
+              Restore Previous Download
+            </button>
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
+};
+
+const mapStateToProps = state => {
+  return {
+    state,
+    numTransactions: state.transactions.data.length
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    restoreStateFromFile: newState => {
+      dispatch(actions.restoreStateFromFile(newState));
+    }
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Data);

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 const IntroWithData = () => {
   return (
@@ -8,14 +9,17 @@ const IntroWithData = () => {
       <h1 className="display-4">Welcome back</h1>
       <p className="lead">Looks like you have been here before :-)</p>
       <hr />
-      <Link className="btn btn-primary" to="/upload">
+      <Link className="btn btn-primary" to="/transaction/upload">
+        <FontAwesomeIcon icon="upload" className="mr-1" fixedWidth />
         Upload more transactions
       </Link>
-      <Link className="btn btn-secondary mx-2" to="/chart">
-        Charts
+      <Link className="btn btn-secondary mx-2" to="/transaction">
+        <FontAwesomeIcon icon="table" className="mr-1" fixedWidth />
+        Existing transactions
       </Link>
-      <Link className="btn btn-secondary" to="/transaction">
-        All transactions
+      <Link className="btn btn-secondary" to="/chart">
+        <FontAwesomeIcon icon="chart-bar" className="mr-1" fixedWidth />
+        Charts
       </Link>
     </div>
   );
@@ -30,7 +34,7 @@ const IntroWithoutData = () => {
       <p>
         Catchy headline eh? But seriously, if you have a list of bank transactions, and you want to see some pretty graphs, go ahead and upload the file here. It will never be stored anywhere.
       </p>
-      <Link className="btn btn-dark btn-lg" to="/upload">Get Started</Link>
+      <Link className="btn btn-dark btn-lg" to="/transaction/upload">Get Started</Link>
     </div>
   );
 };

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { show } from 'redux-modal';
 import { toggleLocalStorage } from '../actions';
+import SaveData from './modals/SaveData';
 
 class Menu extends React.Component {
   constructor(props) {
@@ -42,23 +45,33 @@ class Menu extends React.Component {
     if (this.props.match.url === '/') return null;
 
     const active = url => {
-      return this.props.match.url === url ? ' active' : '';
+      return this.props.match.url.startsWith(url) ? ' active' : '';
     }
 
     return (
+      <React.Fragment>
       <nav className="navbar navbar-expand-md navbar-dark bg-dark">
         <div className="container">
           <Link className="navbar-brand" to="/">Off The Books</Link>
           <div className="navbar-collapse">
             <ul className="navbar-nav mr-auto">
-              <li className={`nav-item${active('/upload')}`}>
-                <Link className="nav-link" to="/upload">Upload</Link>
+              <li className={`nav-item${active('/transaction')}`}>
+                <Link className="nav-link" to="/transaction">
+                  <FontAwesomeIcon icon="table" className="mr-1" fixedWidth />
+                  Transactions
+                </Link>
               </li>
               <li className={`nav-item${active('/chart')}`}>
-                <Link className="nav-link" to="/chart">Charts</Link>
+                <Link className="nav-link" to="/chart">
+                  <FontAwesomeIcon icon="chart-bar" className="mr-1" fixedWidth />
+                  Charts
+                </Link>
               </li>
-              <li className={`nav-item${active('/transaction')}`}>
-                <Link className="nav-link" to="/transaction">Transactions</Link>
+              <li className={`nav-item${active('/data')}`}>
+                <Link className="nav-link" to="/data">
+                  <FontAwesomeIcon icon="database" className="mr-1" fixedWidth />
+                  Manage Data
+                </Link>
               </li>
             </ul>
             <form className="form-inline">
@@ -75,9 +88,19 @@ class Menu extends React.Component {
                 </label>
               </div>
             </form>
+            <div className="navbar-text text-info">
+              <FontAwesomeIcon
+                icon="question-circle"
+                className="ml-1"
+                fixedWidth
+                onClick={() => this.props.showModal(SaveData.modalName)}
+              />
+            </div>
           </div>
         </div>
       </nav>
+      <SaveData />
+      </React.Fragment>
     );
   }
 };
@@ -92,6 +115,9 @@ const mapDispatchToProps = dispatch => {
   return {
     toggleLocalStorage: enabled => {
       dispatch(toggleLocalStorage(enabled));
+    },
+    showModal: (...args) => {
+      dispatch(show(...args));
     }
   };
 };

--- a/src/components/NoData.js
+++ b/src/components/NoData.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const NoData = () => {
+  return (
+    <div className="row">
+      <div className="col">
+        <p>No data yet. <Link to="/transaction/upload">Add some</Link>.</p>
+      </div>
+    </div>
+  );
+};
+
+export default NoData;

--- a/src/components/TransactionUpload.js
+++ b/src/components/TransactionUpload.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import Papa from 'papaparse';
 import * as actions from '../actions';
 
@@ -16,13 +16,13 @@ class UploadForm extends React.Component {
   handleSave() {
     this.fileInput.value = '';
     this.props.handleSave();
-    this.props.history.push('/chart')
+    this.props.history.push('/transaction')
   }
 
   handleCancel() {
     this.fileInput.value = '';
     this.props.handleCancel();
-    this.props.history.push('/chart')
+    this.props.history.push('/transaction')
   }
 
   render() {
@@ -136,6 +136,12 @@ const TransactionTable = props => {
 const TransactionUpload = props => {
   return (
     <React.Fragment>
+      <nav aria-label="breadcrumb">
+        <ol className="breadcrumb">
+          <li className="breadcrumb-item"><Link to="/transaction">Transactions</Link></li>
+          <li className="breadcrumb-item active" aria-current="page">Upload</li>
+        </ol>
+      </nav>
       <UploadForm
         handleFileChange={props.handleFileChange}
         handleSkipRowsChange={props.handleSkipRowsChange}

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import * as actions from '../actions';
+import NoData from './NoData';
 
 // XXX: This is not nice :-)
 const categories = [
@@ -89,7 +91,7 @@ const TransactionTable = props => {
   return (
     <div className="row justify-content-center">
       <div className="col">
-        <table className="table table-striped">
+        <table className="table table-striped mt-3">
           <thead>
             <tr>
               <th>Date</th>
@@ -116,12 +118,21 @@ const TransactionTable = props => {
 }
 
 const Transactions = props => {
+  if (props.transactions.length === 0) return <NoData />;
+
   return (
-    <TransactionTable
-      transactions={props.transactions}
-      handleRowCategory={props.handleRowCategory}
-      handleGuessCategoryForRow={props.handleGuessCategoryForRow}
-    />
+    <React.Fragment>
+      <div className="row">
+        <div className="col">
+          <Link to="/transaction/upload" className="btn btn-outline-primary">Add More Transactions</Link>
+        </div>
+      </div>
+      <TransactionTable
+        transactions={props.transactions}
+        handleRowCategory={props.handleRowCategory}
+        handleGuessCategoryForRow={props.handleGuessCategoryForRow}
+      />
+    </React.Fragment>
   );
 };
 

--- a/src/components/Transactions.test.js
+++ b/src/components/Transactions.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import { MemoryRouter } from 'react-router-dom';
+import { shallow, mount } from 'enzyme';
+import Transactions from './Transactions';
+
+describe('Transactions', () => {
+  const mockStore = configureStore();
+
+  it('should render nothing when there are no transactions', () => {
+    const store = mockStore({
+      transactions: {
+        data: []
+      }
+    });
+
+    const container = shallow(
+      <MemoryRouter>
+        <Transactions store={store} />
+      </MemoryRouter>
+    );
+    expect(container.render().text()).toEqual('No data yet. Add some.');
+  });
+
+  it('should render a table of transactions', () => {
+    const store = mockStore({
+      transactions: {
+        data: [
+          {
+            id: 'abcd',
+            date: '2018-01-01',
+            amount: 1,
+            description: 'test',
+            total: 2,
+            category: {
+              guess: '',
+              confirmed: 'food'
+            }
+          }
+        ]
+      }
+    });
+
+    const container = shallow(
+      <MemoryRouter>
+        <Transactions store={store} />
+      </MemoryRouter>
+    ).render();
+    expect(container.find('table').length).toEqual(1);
+
+    const row = container.find('tr').eq(1);
+    expect(row.find('td').eq(0).text()).toEqual('2018-01-01');
+    expect(row.find('td').eq(1).text()).toEqual('test');
+    expect(row.find('td').eq(2).text()).toEqual('1');
+    expect(row.find('td').eq(3).text()).toEqual('2');
+    expect(row.find('td').eq(4).text()).toEqual('food');
+  });
+});

--- a/src/components/modals/SaveData.js
+++ b/src/components/modals/SaveData.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { connectModal } from 'redux-modal';
+
+const SAVE_DATA_MODAL = 'save-data';
+
+const SaveData = connectModal({ name: SAVE_DATA_MODAL })(props => {
+  if (!props.show) return null;
+
+  return (
+    <div className="modal" style={{display: 'block'}}>
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h6 className="modal-title">
+              Saving data in the browser?
+            </h6>
+          </div>
+          <div className="modal-body">
+            <p>
+              If enabled, the data will be saved in the browser&#39;s local storage.
+              The data will be available if you close and re-open the
+              browser, but it will <em>not</em> be accessible by other
+              websites.
+            </p>
+            <p>
+              On a shared machine, this feature is not recommended. Download
+              the data instead, and restore it later with the restore function.
+            </p>
+          </div>
+          <div className="modal-footer">
+            <div className="container-fluid">
+              <div className="row justify-content-center">
+                <div className="col-auto">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={props.handleHide}
+                >
+                  Cool
+                </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+SaveData.modalName = SAVE_DATA_MODAL;
+
+export default SaveData;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,15 @@ import registerServiceWorker from './registerServiceWorker';
 
 import 'bootstrap/dist/css/bootstrap.css'; // Makes sure bootstrap is always available.
 
+// Build the fontawesome library
+import fontawesome from '@fortawesome/fontawesome';
+import faUpload from '@fortawesome/fontawesome-free-solid/faUpload';
+import faChartBar from '@fortawesome/fontawesome-free-solid/faChartBar';
+import faTable from '@fortawesome/fontawesome-free-solid/faTable';
+import faDatabase from '@fortawesome/fontawesome-free-solid/faDatabase';
+import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
+fontawesome.library.add(faUpload, faChartBar, faTable, faDatabase, faQuestionCircle);
+
 const { store, persistor } = configureStore({});
 
 ReactDOM.render(

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux';
+import { reducer as modalReducer } from 'redux-modal';
 import update from 'immutability-helper';
 import bayes from 'bayes';
 import uuidv4 from 'uuid/v4';
@@ -29,6 +30,11 @@ const appReducer = (state = initialApp, action) => {
             $set: action.enabled
           }
         }
+      });
+    case actions.RESTORE_STATE_FROM_FILE:
+      if (!action.newState.app) return state;
+      return update(state, {
+        $set: action.newState.app
       });
     default:
       return state;
@@ -156,7 +162,12 @@ const transactionReducer = (state = initialTransactions, action) => {
             }
           }
         }
-      })
+      });
+    case actions.RESTORE_STATE_FROM_FILE:
+      if (!action.newState.transactions) return state;
+      return update(state, {
+        $set: action.newState.transactions
+      });
     default:
       return state;
   }
@@ -164,5 +175,6 @@ const transactionReducer = (state = initialTransactions, action) => {
 
 export default combineReducers({
   app: appReducer,
-  transactions: transactionReducer
+  transactions: transactionReducer,
+  modal: modalReducer
 });

--- a/src/reducers.test.js
+++ b/src/reducers.test.js
@@ -223,3 +223,17 @@ describe('guess category', () => {
     });
   });
 });
+
+describe('restore from file', () => {
+  it('should restore from file', () => {
+    const state = reducers({}, actions.restoreStateFromFile({
+      transactions: {
+        data: [{ id: 'abcd' }]
+      }
+    }));
+
+    expect(state.transactions.data).toEqual([
+      { id: 'abcd' }
+    ])
+  });
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,28 @@
 # yarn lockfile v1
 
 
+"@fortawesome/fontawesome-common-types@^0.1.3", "@fortawesome/fontawesome-common-types@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.4.tgz#1fbc66f0223646f23c5550c2c12e341078e2c262"
+
+"@fortawesome/fontawesome-free-solid@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.10.tgz#b54c87d3ce4ffd0546b60d12e898e87b59776c30"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.1.4"
+
+"@fortawesome/fontawesome@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-1.1.5.tgz#c7cfafdd3364245626293cc670357f9fb8487170"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.1.3"
+
+"@fortawesome/react-fontawesome@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.0.18.tgz#4e0eb1cf9797715a67bb7705ae084fa0a410f185"
+  dependencies:
+    humps "^2.0.1"
+
 "@types/node@*":
   version "9.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.2.tgz#e49ac1adb458835e95ca6487bc20f916b37aff23"
@@ -2236,6 +2258,10 @@ dotenv@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3369,7 +3395,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -3517,6 +3543,10 @@ http-signature@~1.2.0:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
 
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -6141,6 +6171,13 @@ redux-mock-store@^1.5.1:
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
   dependencies:
     lodash.isplainobject "^4.0.6"
+
+redux-modal@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/redux-modal/-/redux-modal-1.7.3.tgz#24ee7d6abb6f9644aff918dc65d5683b7609122f"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+    prop-types "^15.5.10"
 
 redux-persist@^5.9.1:
   version "5.9.1"


### PR DESCRIPTION
This commit adds a new "manage data" page where it is possible to
download and restore all data.

Also included are a number of UI improvements such as font-awesome icons
and a modal that explains what "save data in the browser" means.

The transaction upload has been nested under the transactions page.