### PR TITLE
Add CRUD operations for categories

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,6 +9,10 @@ export const GUESS_CATEGORY_FOR_ROW = 'GUESS_CATEGORY_FOR_ROW';
 export const EDIT_CATEGORY_FOR_ROW = 'EDIT_CATEGORY_FOR_ROW';
 export const CATEGORIZE_ROW = 'CATEGORIZE_ROW';
 export const RESTORE_STATE_FROM_FILE = 'RESTORE_STATE_FROM_FILE';
+export const ADD_CATEGORY = 'ADD_CATEGORY';
+export const UPDATE_CATEGORY = 'UPDATE_CATEGORY';
+export const DELETE_CATEGORY = 'DELETE_CATEGORY';
+export const SET_PARENT_CATEGORY = 'SET_PARENT_CATEGORY';
 
 export const parseTransactionsStart = () => {
   return {
@@ -83,5 +87,37 @@ export const restoreStateFromFile = newState => {
   return {
     type: RESTORE_STATE_FROM_FILE,
     newState
+  };
+};
+
+export const addCategory = (name, parentId) => {
+  return {
+    type: ADD_CATEGORY,
+    name,
+    parentId
+  };
+};
+
+export const updateCategory = (categoryId, name, parentId) => {
+  return {
+    type: UPDATE_CATEGORY,
+    categoryId,
+    name,
+    parentId
+  };
+};
+
+export const setParentCategory = (categoryId, parentId) => {
+  return {
+    type: SET_PARENT_CATEGORY,
+    categoryId,
+    parentId
+  };
+};
+
+export const deleteCategory = categoryId => {
+  return {
+    type: DELETE_CATEGORY,
+    categoryId
   };
 };

--- a/src/components/Categories.js
+++ b/src/components/Categories.js
@@ -1,0 +1,226 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { show, hide } from 'redux-modal';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import * as actions from '../actions';
+import Confirm from './modals/Confirm';
+
+const NEW_CATEGORY_NAME = 'New Category';
+
+const ConfirmDelete = props => {
+  return (
+    <React.Fragment>
+      {props.numTransactions > 0 && <div className="alert alert-danger">
+        Deleting &quot;{props.categoryName}&quot; will affect {props.numTransactions} transactions. Their category selection will be reset, and you will have to re-categorize them later.
+      </div>}
+      Are you sure you want to delete &quot;{props.categoryName}&quot;?
+    </React.Fragment>
+  );
+};
+
+const CategoryEdit = props => {
+  return (
+    <form className="form-inline" onSubmit={e => {
+      e.preventDefault();
+      props.handleSave();
+    }}>
+      <div className="form-group">
+        <input
+          ref={props.textRef}
+          type="text"
+          className="form-control form-control-sm"
+          value={props.categoryName}
+          onChange={props.handleChange}
+          onKeyDown={e => e.keyCode === 27 && props.handleCancel()}
+        />
+      </div>
+      <button type="submit" className="btn btn-success btn-sm mx-2">
+        Save
+      </button>
+      <button
+        type="button"
+        className="btn btn-danger btn-sm"
+        onClick={props.handleCancel}
+      >
+        Cancel
+      </button>
+    </form>
+  );
+};
+
+CategoryEdit.propTypes = {
+  categoryName: PropTypes.string.isRequired,
+};
+
+class Category extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { editing: false };
+
+    this.textRef = React.createRef();
+
+    this.handleEditCategory = this.handleEditCategory.bind(this);
+    this.handleSave = this.handleSave.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
+    this.handleDeleteConfirm = this.handleDeleteConfirm.bind(this);
+  }
+
+  componentDidMount() {
+    // This is the easy way to make sure a new category is in edit mode.
+    // However, it might not be best practice.
+    if (this.props.category.name === NEW_CATEGORY_NAME) this.handleEditCategory();
+  }
+
+  handleEditCategory() {
+    this.setState({
+      editing: true,
+      value: this.props.category.name
+    }, () => this.textRef.current.focus());
+  }
+
+  handleSave() {
+    this.props.handleUpdateCategory(this.props.category.id, this.state.value);
+    this.setState({ editing: false });
+  }
+
+  handleCancel() {
+    this.setState({ editing: false });
+  }
+
+  handleChange(e) {
+    this.setState({ value: e.target.value });
+  }
+
+  async handleDelete() {
+    await this.props.hideModal(Confirm.modalName);
+    return this.props.handleDeleteCategory(this.props.category.id);
+  }
+
+  handleDeleteConfirm() {
+    const numTransactions = this.props.transactions
+      .filter(t => t.category.confirmed === this.props.category.id)
+      .length;
+    this.props.showModal(Confirm.modalName, {
+      handleYes: this.handleDelete,
+      body: <ConfirmDelete
+        categoryName={this.props.category.name}
+        numTransactions={numTransactions}
+      />
+    });
+  }
+
+  render() {
+    if (this.state.editing) {
+      return <CategoryEdit
+        textRef={this.textRef}
+        categoryName={this.state.value}
+        handleSave={this.handleSave}
+        handleCancel={this.handleCancel}
+        handleChange={this.handleChange}
+      />
+    }
+
+    return (
+      <li>
+        <span
+          className="cursor-pointer"
+          onClick={this.handleEditCategory}
+        >
+          {this.props.category.name}
+          <FontAwesomeIcon
+            icon="edit"
+            className="ml-2"
+          />
+        </span>
+        <FontAwesomeIcon
+          icon="trash-alt"
+          className="ml-2 cursor-pointer"
+          onClick={this.handleDeleteConfirm}
+        />
+      </li>
+    );
+  }
+}
+
+Category.propTypes = {
+  showModal: PropTypes.func.isRequired,
+  hideModal: PropTypes.func.isRequired,
+  category: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }).isRequired
+};
+
+const Categories = props => {
+  return (
+    <React.Fragment>
+      <div className="row">
+        <div className="col">
+          <ul>
+            {props.categories.map(c => {
+              return <Category
+                key={`cat-${c.id}`}
+                category={c}
+                transactions={props.transactions}
+                handleUpdateCategory={props.handleUpdateCategory}
+                handleDeleteCategory={props.handleDeleteCategory}
+                showModal={props.showModal}
+                hideModal={props.hideModal}
+              />
+            })}
+          </ul>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col">
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            onClick={() => props.handleAddCategory(NEW_CATEGORY_NAME)}
+          >
+            <FontAwesomeIcon
+              icon="plus"
+              className="mr-1"
+              fixedWidth
+            />
+            Add New Category
+          </button>
+        </div>
+      </div>
+      <Confirm />
+    </React.Fragment>
+  );
+};
+
+const mapStateToProps = state => {
+  return {
+    categories: state.categories.data,
+    transactions: state.transactions.data
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    handleUpdateCategory: (categoryId, name) => {
+      dispatch(actions.updateCategory(categoryId, name));
+    },
+    handleAddCategory: name => {
+      dispatch(actions.addCategory(name));
+    },
+    handleDeleteCategory: categoryId => {
+      dispatch(actions.deleteCategory(categoryId));
+    },
+    showModal: (...args) => {
+      dispatch(show(...args));
+    },
+    hideModal: (...args) => {
+      dispatch(hide(...args));
+    }
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Categories);

--- a/src/components/Data.js
+++ b/src/components/Data.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import download from 'downloadjs';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import RestoreData from './RestoreData';
+import Categories from './Categories';
 
 class Data extends React.Component {
   constructor(props) {
@@ -30,18 +31,25 @@ class Data extends React.Component {
           </div>
         </div>
         <div className="row">
-          <div className="col-auto">
+          <div className="col">
             <button
               type="button"
-              className="btn btn-outline-primary"
+              className="btn btn-outline-primary m-1"
               onClick={this.handleDownload}
             >
               <FontAwesomeIcon icon="download" className="mr-1" fixedWidth />
               Download All Data
             </button>
-            <RestoreData>
+            <RestoreData className="btn btn-outline-secondary m-1">
               Restore Previous Download
             </RestoreData>
+          </div>
+        </div>
+        <hr />
+        <div className="row">
+          <div className="col">
+            <h3>Categories</h3>
+            <Categories />
           </div>
         </div>
       </React.Fragment>

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -13,15 +13,15 @@ const IntroWithData = props => {
         You have {props.numTransactions} transactions so far.
       </p>
       <hr />
-      <Link className="btn btn-primary" to="/transaction/upload">
+      <Link className="btn btn-primary m-1" to="/transaction/upload">
         <FontAwesomeIcon icon="upload" className="mr-1" fixedWidth />
         Upload more transactions
       </Link>
-      <Link className="btn btn-secondary mx-2" to="/transaction">
+      <Link className="btn btn-secondary m-1" to="/transaction">
         <FontAwesomeIcon icon="table" className="mr-1" fixedWidth />
         Existing transactions
       </Link>
-      <Link className="btn btn-secondary" to="/chart">
+      <Link className="btn btn-secondary m-1" to="/chart">
         <FontAwesomeIcon icon="chart-bar" className="mr-1" fixedWidth />
         Charts
       </Link>
@@ -41,8 +41,8 @@ const IntroWithoutData = () => {
         upload the file here. The data stays in your browser and is not
         shared or stored anywhere else.
       </p>
-      <Link className="btn btn-primary btn-lg" to="/transaction/upload">Get Started</Link>
-      <RestoreData className="btn btn-secondary btn-lg ml-3">
+      <Link className="btn btn-primary btn-lg m-1" to="/transaction/upload">Get Started</Link>
+      <RestoreData className="btn btn-secondary btn-lg m-1">
         Restore Data from File
         <FontAwesomeIcon
           icon="question-circle"

--- a/src/components/RestoreData.js
+++ b/src/components/RestoreData.js
@@ -49,11 +49,7 @@ class RestoreData extends React.Component {
 
 RestoreData.propTypes = {
   children: PropTypes.any.isRequired,
-  className: PropTypes.string
-};
-
-RestoreData.defaultProps = {
-  className: 'btn btn-outline-secondary ml-2'
+  className: PropTypes.string.isRequired
 };
 
 const mapDispatchToProps = dispatch => {

--- a/src/components/Transactions.test.js
+++ b/src/components/Transactions.test.js
@@ -11,6 +11,9 @@ describe('Transactions', () => {
     const store = mockStore({
       transactions: {
         data: []
+      },
+      categories: {
+        data: []
       }
     });
 
@@ -41,6 +44,9 @@ describe('Transactions', () => {
             }
           }
         ]
+      },
+      categories: {
+        data: [{ id: 'food', name: 'Food' }]
       }
     });
 
@@ -56,8 +62,7 @@ describe('Transactions', () => {
     expect(row.find('td').eq(1).text()).toEqual('test');
     expect(row.find('td').eq(2).text()).toEqual('1');
     expect(row.find('td').eq(3).text()).toEqual('2');
-    expect(row.find('td').eq(4).text()).toEqual('food');
-    expect(row.find('td').eq(4).find('button').length).toEqual(1);
+    expect(row.find('td').eq(4).text()).toEqual('Food');
   });
 
   it('should show guess confirm and edit buttons', () => {
@@ -79,6 +84,9 @@ describe('Transactions', () => {
             }
           }
         ]
+      },
+      categories: {
+        data: [{ id: 'travel', name: 'Travel' }]
       }
     });
 
@@ -90,6 +98,6 @@ describe('Transactions', () => {
 
     const categoryCol = container.find('tr').eq(1).find('td').eq(4);
     expect(categoryCol.find('button').length).toEqual(2);
-    expect(categoryCol.text()).toEqual('travel');
+    expect(categoryCol.text()).toEqual('Travel');
   });
 });

--- a/src/components/modals/Confirm.js
+++ b/src/components/modals/Confirm.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connectModal } from 'redux-modal';
 
-const SAVE_DATA_MODAL = 'save-data';
+const CONFIRM_MODAL = 'confirm';
 
-const SaveData = connectModal({ name: SAVE_DATA_MODAL })(props => {
+const Confirm = connectModal({ name: CONFIRM_MODAL })(props => {
   if (!props.show) return null;
 
   return (
@@ -11,22 +11,12 @@ const SaveData = connectModal({ name: SAVE_DATA_MODAL })(props => {
       <div className="modal" style={{display: 'block'}}>
         <div className="modal-dialog">
           <div className="modal-content">
-            <div className="modal-header">
-              <h6 className="modal-title">
-                Saving data in the browser?
-              </h6>
-            </div>
             <div className="modal-body">
-              <p>
-                If enabled, the data will be saved in the browser&#39;s local storage.
-                The data will be available if you close and re-open the
-                browser, but it will <em>not</em> be accessible by other
-                websites.
-              </p>
-              <p>
-                On a shared machine, this feature is not recommended. Download
-                the data instead, and restore it later with the restore function.
-              </p>
+              <div className="row">
+                <div className="col text-center">
+                  {props.body || 'Are you sure?'}
+                </div>
+              </div>
             </div>
             <div className="modal-footer">
               <div className="container-fluid">
@@ -34,10 +24,17 @@ const SaveData = connectModal({ name: SAVE_DATA_MODAL })(props => {
                   <div className="col-auto">
                     <button
                       type="button"
-                      className="btn btn-secondary"
+                      className="btn btn-primary m-1"
+                      onClick={props.handleYes}
+                    >
+                      Yes
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-secondary m-1"
                       onClick={props.handleHide}
                     >
-                      Cool
+                      No
                     </button>
                   </div>
                 </div>
@@ -51,6 +48,6 @@ const SaveData = connectModal({ name: SAVE_DATA_MODAL })(props => {
   );
 });
 
-SaveData.modalName = SAVE_DATA_MODAL;
+Confirm.modalName = CONFIRM_MODAL;
 
-export default SaveData;
+export default Confirm;

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV === 'development') {
 const persistConfig = {
   key: 'otb',
   storage: storage,
-  blacklist: ['edit']
+  blacklist: ['edit', 'modal']
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -5,3 +5,7 @@
 .small-tip {
   max-width: 200px;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ import faLightbulb from '@fortawesome/fontawesome-free-solid/faLightbulb';
 import faDownload from '@fortawesome/fontawesome-free-solid/faDownload';
 import faThumbsDown from '@fortawesome/fontawesome-free-solid/faThumbsDown';
 import faThumbsUp from '@fortawesome/fontawesome-free-solid/faThumbsUp';
+import faTrashAlt from '@fortawesome/fontawesome-free-solid/faTrashAlt'
+import faPlus from '@fortawesome/fontawesome-free-solid/faPlus'
 fontawesome.library.add(
   faUpload,
   faChartBar,
@@ -31,7 +33,9 @@ fontawesome.library.add(
   faLightbulb,
   faDownload,
   faThumbsUp,
-  faThumbsDown
+  faThumbsDown,
+  faTrashAlt,
+  faPlus
 );
 
 const { store, persistor } = configureStore({});

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -1,0 +1,39 @@
+import update from 'immutability-helper';
+import * as actions from '../actions';
+
+const initialApp = {
+  isParsing: false,
+  storage: {
+    localStorage: false
+  }
+};
+
+const appReducer = (state = initialApp, action) => {
+  switch (action.type) {
+    case actions.PARSE_TRANSACTIONS_START:
+      return update(state, {
+        isParsing: { $set: true }
+      });
+    case actions.PARSE_TRANSACTIONS_END:
+      return update(state, {
+        isParsing: { $set: false }
+      });
+    case actions.TOGGLE_LOCAL_STORAGE:
+      return update(state, {
+        storage: {
+          localStorage: {
+            $set: action.enabled
+          }
+        }
+      });
+    case actions.RESTORE_STATE_FROM_FILE:
+      if (!action.newState.app) return state;
+      return update(state, {
+        $set: action.newState.app
+      });
+    default:
+      return state;
+  }
+};
+
+export default appReducer;

--- a/src/reducers/app.test.js
+++ b/src/reducers/app.test.js
@@ -1,0 +1,33 @@
+import reducers from './index';
+import * as actions from '../actions';
+
+// Using the global reducer make default data nicer.
+
+it('should set default data', () => {
+  const state = reducers({}, { type: 'NOOP' });
+  expect(state.app).toEqual({
+    isParsing: false,
+    storage: {
+      localStorage: false 
+    },
+  });
+});
+
+it('should handle the parsing start action', () => {
+  expect(reducers({}, actions.parseTransactionsStart()).app.isParsing).toEqual(true);
+});
+
+it('should handle the toggle persist action', () => {
+  expect(reducers({}, actions.toggleLocalStorage(true)).app.storage).toEqual({
+    localStorage: true
+  });
+
+  expect(reducers({}, actions.toggleLocalStorage(false)).app.storage).toEqual({
+    localStorage: false
+  });
+});
+
+it('should set parsing to false on parse transaction ending', () => {
+  const state = reducers({ app: { isParsing: true } }, actions.parseTransactionsEnd(null, [['2018-04-06', 'test row', 123, 456]]));
+  expect(state.app.isParsing).toEqual(false);
+})

--- a/src/reducers/categories.js
+++ b/src/reducers/categories.js
@@ -1,0 +1,64 @@
+import update from 'immutability-helper';
+import uuidv4 from 'uuid/v4';
+import * as actions from '../actions';
+
+const initialCategories = {
+  data: [
+    { id: uuidv4(), name: 'Food' },
+    { id: uuidv4(), name: 'Travel' }
+  ]
+};
+
+const categoriesReducer = (state = initialCategories, action) => {
+  switch (action.type) {
+    case actions.ADD_CATEGORY:
+      return update(state, {
+        data: {
+          $push: [{
+            id: uuidv4(),
+            name: action.name,
+            parent: action.parentId
+          }]
+        }
+      });
+    case actions.UPDATE_CATEGORY:
+      const indexToUpdate = state.data.findIndex(c => c.id === action.categoryId);
+      if (indexToUpdate < 0) return state;
+      return update(state, {
+        data: {
+          [indexToUpdate]: {
+            name: {
+              $set: action.name
+            },
+            parent: {
+              $set: action.parentId || ''
+            }
+          }
+        }
+      });
+    case actions.SET_PARENT_CATEGORY:
+      const indexToSet = state.data.findIndex(c => c.id === action.categoryId);
+      if (indexToSet < 0) return state;
+      return update(state, {
+        data: {
+          [indexToSet]: {
+            parent: {
+              $set: action.parentId || ''
+            }
+          }
+        }
+      });
+    case actions.DELETE_CATEGORY:
+      const indexToDelete = state.data.findIndex(c => c.id === action.categoryId);
+      if (indexToDelete < 0) return state;
+      return update(state, {
+        data: {
+          $splice: [[indexToDelete, 1]]
+        }
+      });
+    default:
+      return state;
+  }
+};
+
+export default categoriesReducer;

--- a/src/reducers/categories.test.js
+++ b/src/reducers/categories.test.js
@@ -1,0 +1,57 @@
+import reducers from './index';
+import * as actions from '../actions';
+
+jest.mock('uuid/v4', () => {
+  return jest.fn().mockReturnValue('abcd');
+});
+
+it('should add a new category', () => {
+  const state = reducers({}, actions.addCategory('Lodging', ''));
+
+  expect(state.categories.data).toContainEqual({
+    id: 'abcd',
+    name: 'Lodging',
+    parent: ''
+  });
+});
+
+it('should change the name of a category', () => {
+  const state = reducers({}, actions.updateCategory('abcd', 'New Name', 'efgh'));
+  expect(state.categories.data).toContainEqual({
+    id: 'abcd',
+    name: 'New Name',
+    parent: 'efgh'
+  });
+});
+
+it('should not update the name for an unknon a category ID', () => {
+  const state = reducers({}, actions.updateCategory('doesnotexist', 'New Name'));
+  expect(state.categories.data).not.toContainEqual({
+    id: 'abcd',
+    name: 'New Name',
+    parent: ''
+  });
+});
+
+it('should update the parent of a category', () => {
+  const state = reducers({}, actions.setParentCategory('abcd', 'efgh'));
+  expect(state.categories.data).toContainEqual({
+    id: 'abcd',
+    name: 'Food',
+    parent: 'efgh'
+  });
+});
+
+it('should delete a category', () => {
+  const state = reducers({}, actions.deleteCategory('abcd'));
+  // They all have the same ID in these tests, but it will delete the first one,
+  // which is food currently.
+  expect(state.categories.data).not.toContainEqual({
+    id: 'abcd',
+    name: 'Food',
+  });
+  expect(state.categories.data).toContainEqual({
+    id: 'abcd',
+    name: 'Travel',
+  });
+});

--- a/src/reducers/edit.js
+++ b/src/reducers/edit.js
@@ -1,0 +1,33 @@
+import update from 'immutability-helper';
+import * as actions from '../actions';
+
+const initialEditor = {
+  transactionCategories: new Set()
+};
+
+const editReducer = (state = initialEditor, action) => {
+  switch (action.type) {
+    case actions.EDIT_CATEGORY_FOR_ROW:
+      let rowsToAdd = action.rowId;
+      if (!Array.isArray(rowsToAdd)) {
+        rowsToAdd = [rowsToAdd];
+      }
+      return update(state, {
+        transactionCategories: {
+          $add: rowsToAdd
+        }
+      });
+    case actions.GUESS_CATEGORY_FOR_ROW:
+    case actions.CATEGORIZE_ROW:
+      // Remove all editing categories when guessing and categorizing.
+      return update(state, {
+        transactionCategories: {
+          $remove: Array.from(state.transactionCategories)
+        }
+      });
+    default:
+      return state;
+  }
+};
+
+export default editReducer;

--- a/src/reducers/edit.test.js
+++ b/src/reducers/edit.test.js
@@ -1,0 +1,18 @@
+import reducers from './index';
+import * as actions from '../actions';
+
+it('should add categories being edited', () => {
+  const state = reducers({}, actions.editCategoryForRow('a'));
+  expect(state.edit.transactionCategories.has('a')).toBeTruthy();
+  expect(state.edit.transactionCategories.has('b')).toBeFalsy();
+});
+
+it('should clear categories being edited', () => {
+  const state = reducers({
+    edit: {
+      transactionCategories: new Set(['a', 'b'])
+    }
+  }, actions.guessCategoryForRow('b'));
+
+  expect(state.edit.transactionCategories.size).toEqual(0);
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,14 @@
+import { combineReducers } from 'redux';
+import { reducer as modalReducer } from 'redux-modal';
+import appReducer from './app';
+import editReducer from './edit';
+import transactionsReducer from './transactions';
+import categoriesReducer from './categories';
+
+export default combineReducers({
+  app: appReducer,
+  transactions: transactionsReducer,
+  categories: categoriesReducer,
+  modal: modalReducer,
+  edit: editReducer
+});

--- a/src/reducers/transactions.js
+++ b/src/reducers/transactions.js
@@ -1,74 +1,8 @@
-import { combineReducers } from 'redux';
-import { reducer as modalReducer } from 'redux-modal';
 import update from 'immutability-helper';
 import bayes from 'bayes';
 import uuidv4 from 'uuid/v4';
-import * as actions from './actions';
-import * as util from './util';
-
-const initialApp = {
-  isParsing: false,
-  storage: {
-    localStorage: false
-  }
-};
-
-const appReducer = (state = initialApp, action) => {
-  switch (action.type) {
-    case actions.PARSE_TRANSACTIONS_START:
-      return update(state, {
-        isParsing: { $set: true }
-      });
-    case actions.PARSE_TRANSACTIONS_END:
-      return update(state, {
-        isParsing: { $set: false }
-      });
-    case actions.TOGGLE_LOCAL_STORAGE:
-      return update(state, {
-        storage: {
-          localStorage: {
-            $set: action.enabled
-          }
-        }
-      });
-    case actions.RESTORE_STATE_FROM_FILE:
-      if (!action.newState.app) return state;
-      return update(state, {
-        $set: action.newState.app
-      });
-    default:
-      return state;
-  }
-};
-
-const initialEditor = {
-  transactionCategories: new Set()
-};
-
-const editReducer = (state = initialEditor, action) => {
-  switch (action.type) {
-    case actions.EDIT_CATEGORY_FOR_ROW:
-      let rowsToAdd = action.rowId;
-      if (!Array.isArray(rowsToAdd)) {
-        rowsToAdd = [rowsToAdd];
-      }
-      return update(state, {
-        transactionCategories: {
-          $add: rowsToAdd
-        }
-      });
-    case actions.GUESS_CATEGORY_FOR_ROW:
-    case actions.CATEGORIZE_ROW:
-      // Remove all editing categories when guessing and categorizing.
-      return update(state, {
-        transactionCategories: {
-          $remove: Array.from(state.transactionCategories)
-        }
-      });
-    default:
-      return state;
-  }
-};
+import * as actions from '../actions';
+import * as util from '../util';
 
 const initialTransactions = {
   import: {
@@ -109,7 +43,17 @@ const mapImportToTransactions = transactionsImport => {
     });
 };
 
-const transactionReducer = (state = initialTransactions, action) => {
+const retrainBayes = transactions => {
+  const classifier = bayes();
+  transactions.forEach(t => {
+    if (t.category.confirmed && t.description) {
+      classifier.learn(t.description, t.category.confirmed);
+    }
+  });
+  return classifier;
+};
+
+const transactionsReducer = (state = initialTransactions, action) => {
   switch (action.type) {
     case actions.PARSE_TRANSACTIONS_END:
       return update(state, {
@@ -167,7 +111,6 @@ const transactionReducer = (state = initialTransactions, action) => {
       let newState = state;
       rowIndexes.forEach(i => {
         const guess = guesstimator.categorize(newState.data[i].description);
-        console.log(i, guess);
         newState = update(newState, {
           data: {
             [i]: {
@@ -184,13 +127,22 @@ const transactionReducer = (state = initialTransactions, action) => {
     case actions.CATEGORIZE_ROW:
       const rowIndexCategorize = state.data.findIndex(row => row.id === action.rowId);
       if (rowIndexCategorize < 0) return state;
-      // If there's currently no bayes classifier, create a new one.
-      const classifier = state.categorizer.bayes ?
-        bayes.fromJson(state.categorizer.bayes) :
-        bayes();
+      // If there's currently no bayes classifier or if the category changed from non-empty,
+      // create a new one.
+      let classifier;
+      if (state.categorizer.bayes && !state.data[rowIndexCategorize].category.confirmed) {
+        classifier = bayes.fromJson(state.categorizer.bayes)
+      } else {
+        // Reset the classifier and re-train on all transactions, except the one
+        // we are editing..
+        classifier = retrainBayes(state.data.filter(t => t.id !== action.rowId));
+      }
+
+      // Train on the new category we are about to add
       if (action.category && state.data[rowIndexCategorize].description) {
         classifier.learn(state.data[rowIndexCategorize].description, action.category);
       }
+
       return update(state, {
         categorizer: {
           bayes: {
@@ -213,14 +165,37 @@ const transactionReducer = (state = initialTransactions, action) => {
       return update(state, {
         $set: action.newState.transactions
       });
+    case actions.DELETE_CATEGORY:
+      let retrain = false;
+      for (let i = 0; i < state.data.length; i++) {
+        const t = state.data[i];
+        const unset = [];
+        if (t.category.guess === action.categoryId) unset.push('guess');
+        if (t.category.confirmed === action.categoryId) unset.push('confirmed');
+        if (unset.length > 0) {
+          retrain = true;
+          state = update(state, {
+            data: {
+              [i]: {
+                category: {
+                  $unset: unset
+                }
+              }
+            }
+          });
+        }
+      }
+      if (!retrain) return state;
+      return update(state, {
+        categorizer: {
+          bayes: {
+            $set: retrainBayes(state.data).toJson()
+          }
+        },
+      });
     default:
       return state;
   }
 };
 
-export default combineReducers({
-  app: appReducer,
-  transactions: transactionReducer,
-  modal: modalReducer,
-  edit: editReducer
-});
+export default transactionsReducer;

--- a/src/reducers/transactions.test.js
+++ b/src/reducers/transactions.test.js
@@ -1,6 +1,6 @@
 import bayes from 'bayes';
-import reducers from './reducers';
-import * as actions from './actions';
+import reducers from './index';
+import * as actions from '../actions';
 
 jest.mock('uuid/v4', () => {
   return jest.fn(() => 'abcd');
@@ -8,13 +8,6 @@ jest.mock('uuid/v4', () => {
 
 it('should set default data', () => {
   const state = reducers({}, { type: 'NOOP' });
-  expect(state.app).toEqual({
-    isParsing: false,
-    storage: {
-      localStorage: false 
-    },
-  });
-
   expect(state.transactions).toEqual({
     data: [],
     import: {
@@ -28,25 +21,10 @@ it('should set default data', () => {
   });
 });
 
-it('should handle the parsing start action', () => {
-  expect(reducers({}, actions.parseTransactionsStart()).app.isParsing).toEqual(true);
-});
-
-it('should handle the toggle persist action', () => {
-  expect(reducers({}, actions.toggleLocalStorage(true)).app.storage).toEqual({
-    localStorage: true
-  });
-
-  expect(reducers({}, actions.toggleLocalStorage(false)).app.storage).toEqual({
-    localStorage: false
-  });
-});
-
 describe('import', () => {
   describe('transaction end', () => {
     it('should store transactions and guess column indexes', () => {
-      const state = reducers({ app: { isParsing: true } }, actions.parseTransactionsEnd(null, [['2018-04-06', 'test row', 123, 456]]));
-      expect(state.app.isParsing).toEqual(false);
+      const state = reducers({}, actions.parseTransactionsEnd(null, [['2018-04-06', 'test row', 123, 456]]));
       expect(state.transactions.import).toEqual({
         data: [['2018-04-06', 'test row', 123, 456]],
         skipRows: 0,
@@ -60,7 +38,7 @@ describe('import', () => {
     });
 
     it('should handle columns in different positions', () => {
-      const state = reducers({ app: { isParsing: true } }, actions.parseTransactionsEnd(null, [[123, 'test row', 456, '2018-04-06']]));
+      const state = reducers({}, actions.parseTransactionsEnd(null, [[123, 'test row', 456, '2018-04-06']]));
       expect(state.transactions.import).toEqual({
         data: [[123, 'test row', 456, '2018-04-06']],
         skipRows: 0,
@@ -235,10 +213,7 @@ describe('guess category', () => {
         data: [
           {
             id: 'abcd',
-            date: '2018-04-06',
             description: 'origami',
-            amount: 123,
-            total: 456,
             category: {
               guess: 'travel',
               confirmed: ''
@@ -257,6 +232,30 @@ describe('guess category', () => {
     expect(state.transactions.data[0].category).toEqual({
       confirmed: 'hobby'
     });
+  });
+
+  it('should retrain the classifier when a category changes', () => {
+    const state = reducers({
+      transactions: {
+        categorizer: {
+          bayes: '{"categories":{"hobby":true},"docCount":{"hobby":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"hobby":1},"wordFrequencyCount":{"hobby":{"origami":1}},"options":{}}'
+        },
+        data: [
+          {
+            id: 'abcd',
+            description: 'origami',
+            category: {
+              confirmed: 'hobby'
+            }
+          }
+        ]
+      }
+    }, actions.categorizeRow('abcd', 'food'));
+
+    expect(state.transactions.categorizer.bayes).toEqual(
+      // Expecting it to not know about hobby anymore because origami is now food for some reason.
+      '{"categories":{"food":true},"docCount":{"food":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"food":1},"wordFrequencyCount":{"food":{"origami":1}},"options":{}}'
+    );
   });
 
   it('should not add empty categories to classifier', () => {
@@ -310,33 +309,61 @@ describe('guess category', () => {
   });
 });
 
-describe('restore from file', () => {
-  it('should restore from file', () => {
-    const state = reducers({}, actions.restoreStateFromFile({
-      transactions: {
-        data: [{ id: 'abcd' }]
-      }
-    }));
-
-    expect(state.transactions.data).toEqual([
-      { id: 'abcd' }
-    ])
-  });
-});
-
-
-it('should add categories being edited', () => {
-  const state = reducers({}, actions.editCategoryForRow('a'));
-  expect(state.edit.transactionCategories.has('a')).toBeTruthy();
-  expect(state.edit.transactionCategories.has('b')).toBeFalsy();
-});
-
-it('should clear categories being edited', () => {
-  const state = reducers({
-    edit: {
-      transactionCategories: new Set(['a', 'b'])
+it('should restore from file', () => {
+  const state = reducers({}, actions.restoreStateFromFile({
+    transactions: {
+      data: [{ id: 'abcd' }]
     }
-  }, actions.guessCategoryForRow('b'));
+  }));
 
-  expect(state.edit.transactionCategories.size).toEqual(0);
+  expect(state.transactions.data).toEqual([
+    { id: 'abcd' }
+  ])
 });
+
+it('should reset categories and retrain categorizer when a category is removed', () => {
+  const state = reducers({
+    transactions: {
+      categorizer: {
+        // trained on apple and origami
+        bayes: '{"categories":{"hobby":true,"food":true},"docCount":{"hobby":1,"food":1},"totalDocuments":2,"vocabulary":{"origami":true,"apple":true},"vocabularySize":2,"wordCount":{"hobby":1,"food":1},"wordFrequencyCount":{"hobby":{"origami":1},"food":{"apple":1}},"options":{}}'
+      },
+      data: [
+        {
+          category: {
+            guess: 'food',
+            confirmed: ''
+          }
+        },
+        {
+          description: 'apple',
+          category: {
+            guess: '',
+            confirmed: 'food'
+          }
+        },
+        {
+          description: 'origami',
+          category: {
+            guess: '',
+            confirmed: 'hobby'
+          }
+        }
+      ]
+    }
+  }, actions.deleteCategory('food'));
+
+  expect(state.transactions.data[0].category).toEqual({ confirmed: '' });
+  expect(state.transactions.data[1].category).toEqual({ guess: '' });
+  expect(state.transactions.data[2].category).toEqual({
+    guess: '',
+    confirmed: 'hobby'
+  });
+
+  expect(state.transactions.categorizer.bayes).toEqual(
+    // Expecting it to be trained only on hobby now
+    '{"categories":{"hobby":true},"docCount":{"hobby":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"hobby":1},"wordFrequencyCount":{"hobby":{"origami":1}},"options":{}}'
+  );
+});
+
+it('should retrain')


### PR DESCRIPTION
This commit adds a new "categories" section in the data management tab
such that categories can be created, deleted and updated.

Changes:
- Add category management to data management tab.
- Retrain bayes classifier when a category is deleted or changes for a
  transaction.
- Refactor reducers into separate files for each separate reducer.