### PR TITLE
Add expense summary, use categories for treemap

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -11,78 +11,162 @@ import {
 } from 'recharts';
 import { nest } from 'd3-collection';
 import { sum } from 'd3-array';
+import moment from 'moment';
 import NoData from './NoData';
+import color from '../data/color'
 
-// Bootstrap colors
-// TODO: Should probably find a better way to store these.
-const colors = {
-  dark: '#343a40',
-  white: '#ffffff'
+const AmountCard = props => {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <p className="display-3">{props.value}</p>
+        <h5 className="card-title">{props.title}</h5>
+      </div>
+    </div>
+  )
+};
+
+const findCategory = (categories, categoryId, returnFallback = true) => {
+  const category = categories.find(c => c.id === categoryId);
+  if (!category && returnFallback) return { name: 'Uncategorized' };
+  return category;
+};
+
+const Summary = props => {
+  const expenses = props.transactions.filter(d => d.amount < 0);
+  const incomes = props.transactions.filter(d => d.amount >= 0);
+
+  const expenseTotal = Math.round(Math.abs(sum(expenses, d => d.amount)))
+    .toLocaleString();
+
+  const incomeTotal = Math.round(sum(incomes, d => d.amount))
+    .toLocaleString();
+
+  const largestCategory = nest()
+    .key(d => d.category.confirmed || 'n/a')
+    .rollup(a => sum(a, d => d.amount))
+    .entries(expenses)
+    .sort((a, b) => a.value - b.value)[0];
+
+  let categorySpend;
+  if (largestCategory) {
+    const category = findCategory(props.categories, largestCategory.key);
+    categorySpend = {
+      title: `Spent on "${category.name}"`,
+      value: Math.round(Math.abs(largestCategory.value)).toLocaleString()
+    };
+  }
+
+  return (
+    <React.Fragment>
+      <div className="row mb-3">
+        <div className="col">
+          <AmountCard title="Expenses" value={expenseTotal} />
+        </div>
+        <div className="col">
+          <AmountCard title="Income" value={incomeTotal} />
+        </div>
+        {categorySpend && <div className="col">
+          <AmountCard {...categorySpend} />
+        </div>}
+      </div>
+    </React.Fragment>
+  );
 };
 
 const AmountPerDay = props => {
   const data = nest()
     .key(d => d.date)
     .rollup(a => sum(a, d => d.amount))
-    .entries(props.transactions.data)
+    .entries(props.transactions)
     .sort((a, b) => a.key.localeCompare(b.key))
 
   return (
-    <ResponsiveContainer>
-      <LineChart data={data}>
-        <XAxis dataKey="key" />
-        <YAxis />
-        <Tooltip />
-        <Line
-          type="monotone"
-          dataKey="value"
-          stroke={colors.dark}
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <div className="chart">
+      <ResponsiveContainer>
+        <LineChart data={data}>
+          <XAxis dataKey="key" />
+          <YAxis />
+          <Tooltip />
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke={color.bootstrap.dark}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
   );
 };
 
 const AmountPerCategory = props => {
+  const expenses = props.transactions.filter(t => t.amount < 0);
+
   const data = nest()
-    .key(d => d.description)
+    .key(d => d.category.confirmed || 'n/a')
     .rollup(a => Math.abs(sum(a, d => d.amount)))
-    .entries(props.transactions.data)
-    .sort((a, b) => b.value - a.value);
+    .entries(expenses)
+    .sort((a, b) => b.value - a.value)
+    .map(d => {
+      return {
+        key: findCategory(props.categories, d.key).name,
+        value: d.value
+      };
+    });
 
   return (
-    <ResponsiveContainer>
-      <Treemap
-        data={data}
-        nameKey="key"
-        dataKey="value"
-        stroke={colors.white}
-        fill={colors.dark}
-      >
-        <Tooltip />
-      </Treemap>
-    </ResponsiveContainer>
+    <div className="chart">
+      <ResponsiveContainer>
+        <Treemap
+          data={data}
+          nameKey="key"
+          dataKey="value"
+          stroke={color.bootstrap.white}
+          fill={color.bootstrap.dark}
+        >
+          <Tooltip
+            formatter={val => Math.round(val).toLocaleString()}
+          />
+        </Treemap>
+      </ResponsiveContainer>
+    </div>
   )
 };
 
 const Chart = props => {
-  if (props.transactions.data.length === 0) return <NoData />;
+  if (props.transactions.length === 0) return <NoData />;
 
   return (
-    <div className="row justify-content-center">
-      <div className="col-6 chart">
-        <AmountPerDay {...props} />
+    <React.Fragment>
+      <Summary
+        transactions={props.transactions}
+        categories={props.categories}
+      />
+      <div className="row">
+        <div className="col">
+        </div>
       </div>
-      <div className="col-6 chart">
-        <AmountPerCategory {...props} />
+      <div className="row justify-content-center">
+        <div className="col-6">
+          <h3 className="text-center">Sum of Transactions over time</h3>
+          <AmountPerDay transactions={props.transactions} />
+        </div>
+        <div className="col-6">
+          <h3 className="text-center">Categories where money is spent</h3>
+          <AmountPerCategory
+            transactions={props.transactions}
+            categories={props.categories}
+          />
+        </div>
       </div>
-    </div>
+    </React.Fragment>
   );
 };
 
 const mapStateToProps = state => {
   return {
-    transactions: state.transactions
+    transactions: state.transactions.data,
+    categories: state.categories.data
   };
 };
 

--- a/src/data/color.js
+++ b/src/data/color.js
@@ -1,0 +1,6 @@
+const bootstrapColors = {
+  dark: '#343a40',
+  white: '#ffffff'
+};
+
+export default { bootstrap: bootstrapColors };


### PR DESCRIPTION
This commit makes adds three number cards to charts page showing
expenses, income and the most expensive category.

The treemap is adjusted to show categories instead of individual
transactions which also speeds up rendering a little bit.