### PR TITLE
Add ignore and delete transactions

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,6 +9,7 @@ export const GUESS_CATEGORY_FOR_ROW = 'GUESS_CATEGORY_FOR_ROW';
 export const EDIT_CATEGORY_FOR_ROW = 'EDIT_CATEGORY_FOR_ROW';
 export const CATEGORIZE_ROW = 'CATEGORIZE_ROW';
 export const IGNORE_ROW = 'IGNORE_ROW';
+export const DELETE_ROW = 'DELETE_ROW';
 export const RESTORE_STATE_FROM_FILE = 'RESTORE_STATE_FROM_FILE';
 export const ADD_CATEGORY = 'ADD_CATEGORY';
 export const UPDATE_CATEGORY = 'UPDATE_CATEGORY';
@@ -89,6 +90,13 @@ export const ignoreRow = (rowId, ignore) => {
     type: IGNORE_ROW,
     rowId,
     ignore
+  };
+};
+
+export const deleteRow = rowId => {
+  return {
+    type: DELETE_ROW,
+    rowId
   };
 };
 

--- a/src/components/Chart.test.js
+++ b/src/components/Chart.test.js
@@ -115,4 +115,60 @@ describe('Chart', () => {
     expect(rendered.find('.card').eq(0).text()).toEqual('0Expenses');
     expect(rendered.find('.card').eq(1).text()).toEqual('0Income')
   });
+
+  it('should exclude ignored transactions', () => {
+    const store = mockStore({
+      transactions: {
+        data: [
+          {
+            date: '2018-01-01',
+            amount: -1,
+            category: {},
+            ignore: true
+          },
+          {
+            date: '2018-01-01',
+            amount: -1,
+            category: {}
+          },
+          {
+            date: '2018-01-02',
+            amount: 3,
+            category: {}
+          }
+        ]
+      },
+      categories: {
+        data: []
+      },
+      edit: {
+        dateSelect: {
+          'chart-dates': {
+            startDate: moment('2017-12-01'),
+            endDate: moment('2018-02-01'),
+          }
+        }
+      }
+    });
+
+    const wrapper = mount(<Chart store={store} />);
+    const lineChart = wrapper.find('LineChart');
+    expect(lineChart.length).toEqual(1);
+    expect(lineChart.props().data).toEqual([
+      {
+        key: '2018-01-01',
+        value: -1,
+      },
+      {
+        key: '2018-01-02',
+        value: 3,
+      }
+    ]);
+
+    const summary = wrapper.find('Summary');
+    expect(summary.length).toEqual(1);
+    const rendered = summary.render();
+    expect(rendered.find('.card').eq(0).text()).toEqual('1Expenses');
+    expect(rendered.find('.card').eq(1).text()).toEqual('3Income')
+  });
 });

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -2,208 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { show, hide } from 'redux-modal';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import ReactTooltip from 'react-tooltip';
 import * as actions from '../actions';
+import Confirm from './modals/Confirm';
 import NoData from './NoData';
-
-/**
- * Controls for confirming or rejecting a category guess.
- */
-const CategoryGuessConfirm = props => {
-  return (
-    <React.Fragment>
-      {props.categoryGuessName}
-      <FontAwesomeIcon
-        icon="question-circle"
-        className="text-info ml-1" 
-        data-tip="This is a guess, confirm or edit it on the right"
-      />
-      <button
-        type="button"
-        className="btn btn-outline-success btn-sm ml-1 border-0"
-        onClick={() => props.handleRowCategory(props.transactionId, props.categoryGuess)}
-        title="Confirm Guess"
-      >
-        <FontAwesomeIcon icon="thumbs-up" />
-      </button>
-      <button
-        type="button"
-        className="btn btn-outline-danger btn-sm border-0"
-        onClick={() => props.handleRowCategory(props.transactionId, '')}
-        title="Reject guess"
-      >
-        <FontAwesomeIcon icon="thumbs-down" />
-      </button>
-      <ReactTooltip />
-    </React.Fragment>
-  );
-};
-
-/**
- * Showing a confirmed or guessed category.
- */
-const Category = props => {
-  // 1. If the category has a guess, show that, as well as controls for
-  // confirming the guess.
-  // 2. If the category is confirmed, show an edit button
-  // 3. Otherwise show nothing.
-  if (props.transaction.category.guess) {
-    const categoryName = props.categories
-      .find(c => c.id === props.transaction.category.guess)
-      .name;
-    return <CategoryGuessConfirm
-      transactionId={props.transaction.id}
-      categoryGuess={props.transaction.category.guess}
-      categoryGuessName={categoryName}
-      handleRowCategory={props.handleRowCategory}
-    />;
-  }
-
-  if (props.transaction.category.confirmed) {
-    const categoryName = props.categories
-      .find(c => c.id === props.transaction.category.confirmed)
-      .name;
-    return (
-      <span
-        className="cursor-pointer"
-        onClick={() => props.handleEditCategoryForRow(props.transaction.id)}
-      >
-        {categoryName}
-        <FontAwesomeIcon icon="edit" className="ml-1" fixedWidth />
-      </span>
-    );
-  }
-
-  return null;
-};
-
-Category.propTypes = {
-  handleRowCategory: PropTypes.func.isRequired,
-  handleEditCategoryForRow: PropTypes.func.isRequired,
-  transaction: PropTypes.shape({
-    category: PropTypes.shape({
-      guess: PropTypes.string,
-      confirmed: PropTypes.string
-    }).isRequired
-  }).isRequired
-};
-
-/**
- * A select list for choosing a category.
- */
-const CategorySelect = props => {
-  return (
-    <select
-      className="form-control"
-      onChange={e => props.handleRowCategory(props.transaction.id, e.target.value)}
-    >
-      <option value=""></option>
-      {props.categories.map(category => {
-        return <option
-          key={`cat-${props.transaction.id}-${category.id}`}
-          value={category.id}
-          selected={category.id === props.transaction.category.confirmed}
-        >
-          {category.name}
-        </option>
-      })}
-    </select>
-  );
-};
-
-CategorySelect.propTypes = {
-  handleRowCategory: PropTypes.func.isRequired,
-  transaction: PropTypes.shape({
-    id: PropTypes.string.isRequired
-  }).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
-  }))
-};
-
-const RowCategorizer = props => {
-  const showSelect = props.transaction.editingCategory ||
-    (!props.transaction.category.guess && !props.transaction.category.confirmed);
-
-  return (
-    <React.Fragment>
-      {!showSelect && <Category
-        transaction={props.transaction}
-        categories={props.categories}
-        handleRowCategory={props.handleRowCategory}
-        handleEditCategoryForRow={props.handleEditCategoryForRow}
-      />}
-      {showSelect && <CategorySelect
-        transaction={props.transaction}
-        categories={props.categories}
-        handleRowCategory={props.handleRowCategory}
-      />}
-    </React.Fragment>
-  );
-}
-
-const TransactionRow = props => {
-  return (
-    <tr>
-      <td>
-        {props.transaction.date}
-      </td>
-      <td>
-        {props.transaction.description}
-      </td>
-      <td>
-        {props.transaction.amount}
-      </td>
-      <td>
-        {props.transaction.total}
-      </td>
-      <td>
-        <RowCategorizer {...props} />
-      </td>
-    </tr>
-  );
-};
-
-TransactionRow.propTypes = {
-  transaction: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }).isRequired
-}
-
-const TransactionTable = props => {
-  const data = props.transactions;
-
-  return (
-    <div className="row">
-      <div className="col">
-        <table className="table table-striped mt-3">
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Description</th>
-              <th>Amount</th>
-              <th>Total</th>
-              <th>Category</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((transaction, i) => {
-              return <TransactionRow
-                key={`row-${transaction.id}`}
-                transaction={transaction}
-                categories={props.categories}
-                handleRowCategory={props.handleRowCategory}
-                handleEditCategoryForRow={props.handleEditCategoryForRow}
-              />
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-};
+import TransactionTable from './transactions/TransactionTable';
 
 const Transactions = props => {
   if (props.transactions.length === 0) return <NoData />;
@@ -235,7 +40,13 @@ const Transactions = props => {
         categories={props.categories}
         handleRowCategory={props.handleRowCategory}
         handleEditCategoryForRow={props.handleEditCategoryForRow}
+        handleDeleteRow={props.handleDeleteRow}
+        handleIgnoreRow={props.handleIgnoreRow}
+        showModal={props.showModal}
+        hideModal={props.hideModal}
       />
+      <Confirm />
+      <ReactTooltip />
     </React.Fragment>
   );
 };
@@ -267,6 +78,18 @@ const mapDispatchToProps = dispatch => {
     },
     handleEditCategoryForRow: rowId => {
       dispatch(actions.editCategoryForRow(rowId));
+    },
+    handleDeleteRow: rowId => {
+      dispatch(actions.deleteRow(rowId));
+    },
+    handleIgnoreRow: (rowId, ignore) => {
+      dispatch(actions.ignoreRow(rowId, ignore));
+    },
+    showModal: (...args) => {
+      dispatch(show(...args));
+    },
+    hideModal: (...args) => {
+      dispatch(hide(...args));
     }
   };
 };

--- a/src/components/Transactions.test.js
+++ b/src/components/Transactions.test.js
@@ -4,6 +4,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 import Transactions from './Transactions';
 
+jest.mock('redux-modal', () => {
+  return {
+    connectModal: () => () => () => <span>YOLO</span>
+  };
+});
+
 describe('Transactions', () => {
   const mockStore = configureStore();
 

--- a/src/components/chart/AmountCard.js
+++ b/src/components/chart/AmountCard.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AmountCard = props => {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <p className="display-3">{props.value}</p>
+        <h5 className="card-title">{props.title}</h5>
+      </div>
+    </div>
+  )
+};
+
+AmountCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]).isRequired
+};
+
+export default AmountCard;

--- a/src/components/chart/Summary.js
+++ b/src/components/chart/Summary.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { nest } from 'd3-collection';
+import { sum } from 'd3-array';
+import { findCategory } from '../../util';
+import AmountCard from './AmountCard';
+
+const Summary = props => {
+  const expenses = props.transactions.filter(d => d.amount < 0);
+  const incomes = props.transactions.filter(d => d.amount >= 0);
+
+  const expenseTotal = Math.round(Math.abs(sum(expenses, d => d.amount)))
+    .toLocaleString();
+
+  const incomeTotal = Math.round(sum(incomes, d => d.amount))
+    .toLocaleString();
+
+  const largestCategory = nest()
+    .key(d => d.category.confirmed || 'n/a')
+    .rollup(a => sum(a, d => d.amount))
+    .entries(expenses)
+    .sort((a, b) => a.value - b.value)[0];
+
+  let categorySpend;
+  if (largestCategory) {
+    const category = findCategory(props.categories, largestCategory.key);
+    categorySpend = {
+      title: `Spent on "${category.name}"`,
+      value: Math.round(Math.abs(largestCategory.value)).toLocaleString()
+    };
+  }
+
+  return (
+    <div className="row my-3">
+      <div className="col">
+        <AmountCard title="Expenses" value={expenseTotal} />
+      </div>
+      <div className="col">
+        <AmountCard title="Income" value={incomeTotal} />
+      </div>
+      {categorySpend && <div className="col">
+        <AmountCard {...categorySpend} />
+      </div>}
+    </div>
+  );
+};
+
+Summary.propTypes = {
+  transactions: PropTypes.arrayOf(PropTypes.shape({
+    amount: PropTypes.number.isRequired,
+    category: PropTypes.shape({
+      confirmed: PropTypes.string
+    }).isRequired
+  })).isRequired,
+  categories: PropTypes.arrayOf(PropTypes.shape({
+
+  }))
+};
+
+export default Summary;

--- a/src/components/modals/Confirm.js
+++ b/src/components/modals/Confirm.js
@@ -24,17 +24,17 @@ const Confirm = connectModal({ name: CONFIRM_MODAL })(props => {
                   <div className="col-auto">
                     <button
                       type="button"
-                      className="btn btn-primary m-1"
+                      className={`btn ${props.yesButtonClass || 'btn-primary'} m-1`}
                       onClick={props.handleYes}
                     >
-                      Yes
+                      {props.yesLabel || 'Yes'}
                     </button>
                     <button
                       type="button"
-                      className="btn btn-secondary m-1"
+                      className={`btn ${props.noButtonClass || 'btn-secondary'} m-1`}
                       onClick={props.handleHide}
                     >
-                      No
+                      {props.noLabel || 'No'}
                     </button>
                   </div>
                 </div>

--- a/src/components/transactions/ConfirmDelete.js
+++ b/src/components/transactions/ConfirmDelete.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ConfirmDelete = props => {
+  return (
+    <React.Fragment>
+      <div className="alert alert-danger">
+        This will <em>completely</em> remove the transaction. This is
+        usually only necessary if the transaction is a duplicate or was
+        added by mistake.
+      </div>
+      <div className="alert alert-info">
+        If you do not want the transaction to show up in charts and graphs,
+        it is recommended to use the ignore function instead of deleting.
+        This preserve the correct account balance.
+      </div>
+      Are you sure you want to delete the transaction from {props.transactionDate} with description &quot;{props.transactionDescription}&quot;?
+    </React.Fragment>
+  );
+};
+
+ConfirmDelete.propTypes = {
+  transactionDate: PropTypes.string.isRequired,
+  transactionDescription: PropTypes.string.isRequired
+};
+
+export default ConfirmDelete;

--- a/src/components/transactions/IgnoreTransaction.js
+++ b/src/components/transactions/IgnoreTransaction.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+
+const IgnoreTransaction = props => {
+  if (!props.isIgnored) {
+    return (
+      <FontAwesomeIcon
+        icon="ban"
+        className="cursor-pointer"
+        data-tip="Ignore row in charts. This is useful if the transaction is not actually an income or expense, e.g. transfers between accounts"
+        onClick={() => props.handleIgnoreRow(props.transactionId, true)}
+        fixedWidth
+      />
+    );
+  }
+
+  return (
+    <FontAwesomeIcon
+      icon="plus"
+      className="cursor-pointer"
+      data-tip="Include row in charts."
+      onClick={() => props.handleIgnoreRow(props.transactionId, false)}
+      fixedWidth
+    />
+  );
+};
+
+IgnoreTransaction.propTypes = {
+  transactionId: PropTypes.string.isRequired,
+  isIgnored: PropTypes.bool.isRequired,
+  handleIgnoreRow: PropTypes.func.isRequired
+};
+
+export default IgnoreTransaction;

--- a/src/components/transactions/RowCategorizer.js
+++ b/src/components/transactions/RowCategorizer.js
@@ -1,0 +1,157 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+
+/**
+ * Controls for confirming or rejecting a category guess.
+ */
+const CategoryGuessConfirm = props => {
+  return (
+    <React.Fragment>
+      {props.categoryGuessName}
+      <FontAwesomeIcon
+        icon="question-circle"
+        className="text-info ml-1" 
+        data-tip="This is a guess, confirm or edit it on the right"
+      />
+      <button
+        type="button"
+        className="btn btn-outline-success btn-sm ml-1 border-0"
+        onClick={() => props.handleRowCategory(props.transactionId, props.categoryGuess)}
+        title="Confirm Guess"
+      >
+        <FontAwesomeIcon icon="thumbs-up" />
+      </button>
+      <button
+        type="button"
+        className="btn btn-outline-danger btn-sm border-0"
+        onClick={() => props.handleRowCategory(props.transactionId, '')}
+        title="Reject guess"
+      >
+        <FontAwesomeIcon icon="thumbs-down" />
+      </button>
+    </React.Fragment>
+  );
+};
+
+/**
+ * Showing a confirmed or guessed category.
+ */
+const Category = props => {
+  // 1. If the category has a guess, show that, as well as controls for
+  // confirming the guess.
+  // 2. If the category is confirmed, show an edit button
+  // 3. Otherwise show nothing.
+  if (props.transaction.category.guess) {
+    const categoryName = props.categories
+      .find(c => c.id === props.transaction.category.guess)
+      .name;
+    return <CategoryGuessConfirm
+      transactionId={props.transaction.id}
+      categoryGuess={props.transaction.category.guess}
+      categoryGuessName={categoryName}
+      handleRowCategory={props.handleRowCategory}
+    />;
+  }
+
+  if (props.transaction.category.confirmed) {
+    const categoryName = props.categories
+      .find(c => c.id === props.transaction.category.confirmed)
+      .name;
+    return (
+      <span
+        className="cursor-pointer"
+        onClick={() => props.handleEditCategoryForRow(props.transaction.id)}
+      >
+        {categoryName}
+        <FontAwesomeIcon icon="edit" className="ml-1" fixedWidth />
+      </span>
+    );
+  }
+
+  return null;
+};
+
+Category.propTypes = {
+  handleRowCategory: PropTypes.func.isRequired,
+  handleEditCategoryForRow: PropTypes.func.isRequired,
+  transaction: PropTypes.shape({
+    category: PropTypes.shape({
+      guess: PropTypes.string,
+      confirmed: PropTypes.string
+    }).isRequired
+  }).isRequired
+};
+
+/**
+ * A select list for choosing a category.
+ */
+const CategorySelect = props => {
+  return (
+    <select
+      className="form-control"
+      onChange={e => props.handleRowCategory(props.transaction.id, e.target.value)}
+      value={props.transaction.category.confirmed}
+    >
+      <option value=""></option>
+      {props.categories.map(category => {
+        return <option
+          key={`cat-${props.transaction.id}-${category.id}`}
+          value={category.id}
+        >
+          {category.name}
+        </option>
+      })}
+    </select>
+  );
+};
+
+CategorySelect.propTypes = {
+  handleRowCategory: PropTypes.func.isRequired,
+  transaction: PropTypes.shape({
+    id: PropTypes.string.isRequired
+  }).isRequired,
+  categories: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  })).isRequired
+};
+
+const RowCategorizer = props => {
+  const showSelect = props.transaction.editingCategory ||
+    (!props.transaction.category.guess && !props.transaction.category.confirmed);
+
+  return (
+    <React.Fragment>
+      {!showSelect && <Category
+        transaction={props.transaction}
+        categories={props.categories}
+        handleRowCategory={props.handleRowCategory}
+        handleEditCategoryForRow={props.handleEditCategoryForRow}
+      />}
+      {showSelect && <CategorySelect
+        transaction={props.transaction}
+        categories={props.categories}
+        handleRowCategory={props.handleRowCategory}
+      />}
+    </React.Fragment>
+  );
+};
+
+RowCategorizer.propTypes = {
+  handleRowCategory: PropTypes.func.isRequired,
+  handleEditCategoryForRow: PropTypes.func.isRequired,
+  transaction: PropTypes.shape({
+    category: PropTypes.shape({
+      guess: PropTypes.string,
+      confirmed: PropTypes.string
+    }).isRequired,
+    editingCategory: PropTypes.bool.isRequired
+  }).isRequired,
+  categories: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  })).isRequired
+};
+
+export default RowCategorizer;

--- a/src/components/transactions/TransactionRow.js
+++ b/src/components/transactions/TransactionRow.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import Confirm from '../modals/Confirm';
+import RowCategorizer from './RowCategorizer';
+import IgnoreTransaction from './IgnoreTransaction';
+import ConfirmDelete from './ConfirmDelete';
+
+const TransactionRow = props => {
+  const handleDelete = async () => {
+    await props.hideModal(Confirm.modalName);
+    props.handleDeleteRow(props.transaction.id);
+  };
+
+  const handleDeleteConfirm = () => {
+    props.showModal(Confirm.modalName, {
+      handleYes: handleDelete,
+      yesLabel: "Yes, delete it",
+      yesButtonClass: "btn-danger",
+      body: <ConfirmDelete
+        transactionDate={props.transaction.date}
+        transactionDescription={props.transaction.description}
+      />
+    });
+  }
+
+  const className = props.transaction.ignore ? 'table-warning' : '';
+
+  return (
+    <tr className={className}>
+      <td>
+        {props.transaction.date}
+      </td>
+      <td>
+        {props.transaction.description}
+      </td>
+      <td>
+        {props.transaction.amount}
+      </td>
+      <td>
+        {props.transaction.total}
+      </td>
+      <td>
+        <RowCategorizer
+          transaction={props.transaction}
+          categories={props.categories}
+          handleEditCategoryForRow={props.handleEditCategoryForRow}
+          handleRowCategory={props.handleRowCategory}
+        />
+      </td>
+      <td>
+        <div className="d-inline-flex">
+          <IgnoreTransaction
+            transactionId={props.transaction.id}
+            handleIgnoreRow={props.handleIgnoreRow}
+            isIgnored={!!props.transaction.ignore}
+          />
+          <FontAwesomeIcon
+            icon="trash-alt"
+            className="cursor-pointer text-danger"
+            data-tip="Delete row"
+            onClick={handleDeleteConfirm}
+            fixedWidth
+          />
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+TransactionRow.propTypes = {
+  transaction: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    ignore: PropTypes.bool
+  }).isRequired,
+  categories: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  })).isRequired,
+  showModal: PropTypes.func.isRequired,
+  hideModal: PropTypes.func.isRequired,
+  handleDeleteRow: PropTypes.func.isRequired,
+  handleIgnoreRow: PropTypes.func.isRequired,
+  handleEditCategoryForRow: PropTypes.func.isRequired,
+  handleRowCategory: PropTypes.func.isRequired
+};
+
+export default TransactionRow;

--- a/src/components/transactions/TransactionTable.js
+++ b/src/components/transactions/TransactionTable.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TransactionRow from './TransactionRow';
+
+const TransactionTable = props => {
+  const data = props.transactions;
+
+  return (
+    <div className="row">
+      <div className="col">
+        <table className="table table-striped mt-3">
+          <thead className="thead-dark">
+            <tr>
+              <th>Date</th>
+              <th>Description</th>
+              <th>Amount</th>
+              <th>Total</th>
+              <th>Category</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((transaction, i) => {
+              return <TransactionRow
+                key={`row-${transaction.id}`}
+                transaction={transaction}
+                categories={props.categories}
+                handleRowCategory={props.handleRowCategory}
+                handleEditCategoryForRow={props.handleEditCategoryForRow}
+                handleDeleteRow={props.handleDeleteRow}
+                handleIgnoreRow={props.handleIgnoreRow}
+                showModal={props.showModal}
+                hideModal={props.hideModal}
+              />
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+TransactionTable.propTypes = {
+  transactions: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired
+  })).isRequired,
+  categories: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  })).isRequired,
+  showModal: PropTypes.func.isRequired,
+  hideModal: PropTypes.func.isRequired,
+  handleIgnoreRow: PropTypes.func.isRequired,
+  handleDeleteRow: PropTypes.func.isRequired,
+  handleEditCategoryForRow: PropTypes.func.isRequired,
+  handleRowCategory: PropTypes.func.isRequired,
+};
+
+export default TransactionTable;

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,9 @@ import faLightbulb from '@fortawesome/fontawesome-free-solid/faLightbulb';
 import faDownload from '@fortawesome/fontawesome-free-solid/faDownload';
 import faThumbsDown from '@fortawesome/fontawesome-free-solid/faThumbsDown';
 import faThumbsUp from '@fortawesome/fontawesome-free-solid/faThumbsUp';
-import faTrashAlt from '@fortawesome/fontawesome-free-solid/faTrashAlt'
-import faPlus from '@fortawesome/fontawesome-free-solid/faPlus'
+import faTrashAlt from '@fortawesome/fontawesome-free-solid/faTrashAlt';
+import faPlus from '@fortawesome/fontawesome-free-solid/faPlus';
+import faBan from '@fortawesome/fontawesome-free-solid/faBan';
 fontawesome.library.add(
   faUpload,
   faChartBar,
@@ -35,7 +36,8 @@ fontawesome.library.add(
   faThumbsUp,
   faThumbsDown,
   faTrashAlt,
-  faPlus
+  faPlus,
+  faBan
 );
 
 const { store, persistor } = configureStore({});

--- a/src/reducers/transactions.js
+++ b/src/reducers/transactions.js
@@ -208,6 +208,14 @@ const transactionsReducer = (state = initialTransactions, action) => {
           [indexToIgnore]: op
         }
       });
+    case actions.DELETE_ROW:
+      const indexToDelete = state.data.findIndex(c => c.id === action.rowId);
+      if (indexToDelete < 0) return state;
+      return update(state, {
+        data: {
+          $splice: [[indexToDelete, 1]]
+        }
+      });
     default:
       return state;
   }

--- a/src/reducers/transactions.test.js
+++ b/src/reducers/transactions.test.js
@@ -384,3 +384,14 @@ it('should set a transaction to ignored', () => {
     id: 'abcd'
   });
 });
+
+it('should delete a transaction', () => {
+  const state = reducers({
+    transactions: {
+      data: [
+        { id: 'abcd' }
+      ]
+    }
+  }, actions.deleteRow('abcd'));
+  expect(state.transactions.data).toEqual([]);
+});

--- a/src/util.js
+++ b/src/util.js
@@ -28,3 +28,15 @@ export const guessColumnSpec = transactions => {
 
   return columnSpec;
 };
+
+/**
+ * Search for the category with the given ID in the category list.
+ * @param {Array} categories - A list of categories to search through
+ * @param {String} categoryId - The ID of the category
+ * @param {Boolean} [returnFallback] - Optionally return a fallback category, default is true
+ */
+export const findCategory = (categories, categoryId, returnFallback = true) => {
+  const category = categories.find(c => c.id === categoryId);
+  if (!category && returnFallback) return { name: 'Uncategorized' };
+  return category;
+};


### PR DESCRIPTION
This commit adds UI to the transactions table that allows deleting and
ignoring transaction rows.

Changes:
- Add delete row action and reducers.
- Add UI for ignoring and deleting transaction rows.
- Update transaction filtering for charts to include the ignore flag.
- Refactor some chart and transaction components into separate files. It was needed :)

Closes #18