### PR TITLE
Add react-select and improve naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.4",
+    "react-select": "^2.0.0-beta.6",
     "react-tooltip": "^3.5.1",
     "recharts": "^1.0.0-beta.10",
     "redux": "^3.7.2",

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,7 +6,6 @@ export const CANCEL_TRANSACTIONS = 'CANCEL_TRANSACTIONS';
 export const UPDATE_SKIP_ROWS = 'UPDATE_SKIP_ROWS';
 export const UPDATE_COLUMN_TYPE = 'UPDATE_COLUMN_TYPE';
 export const GUESS_CATEGORY_FOR_ROW = 'GUESS_CATEGORY_FOR_ROW';
-export const EDIT_CATEGORY_FOR_ROW = 'EDIT_CATEGORY_FOR_ROW';
 export const CATEGORIZE_ROW = 'CATEGORIZE_ROW';
 export const IGNORE_ROW = 'IGNORE_ROW';
 export const DELETE_ROW = 'DELETE_ROW';
@@ -66,13 +65,6 @@ export const cancelTransactions = () => {
 export const guessCategoryForRow = rowId => {
   return {
     type: GUESS_CATEGORY_FOR_ROW,
-    rowId
-  };
-};
-
-export const editCategoryForRow = rowId => {
-  return {
-    type: EDIT_CATEGORY_FOR_ROW,
     rowId
   };
 };

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -25,7 +25,7 @@ const Transactions = props => {
             className="btn btn-outline-secondary ml-2"
             onClick={() => {
               const unconfirmedIds = props.transactions
-                .filter(t => !t.category.confirmed)
+                .filter(t => !t.category.confirmed && !t.ignore)
                 .map(t => t.id);
               props.handleGuessCategoryForRow(unconfirmedIds);
             }}
@@ -39,7 +39,6 @@ const Transactions = props => {
         transactions={props.transactions}
         categories={props.categories}
         handleRowCategory={props.handleRowCategory}
-        handleEditCategoryForRow={props.handleEditCategoryForRow}
         handleDeleteRow={props.handleDeleteRow}
         handleIgnoreRow={props.handleIgnoreRow}
         showModal={props.showModal}
@@ -53,18 +52,25 @@ const Transactions = props => {
 
 Transactions.propTypes = {
   transactions: PropTypes.arrayOf(PropTypes.object).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.object).isRequired
+  categories: PropTypes.object.isRequired
 }
 
 const mapStateToProps = state => {
+  const categories = state.categories.data.reduce((obj, category) => {
+    obj[category.id] = category;
+    return obj;
+  }, {});
+
   const transactions = state.transactions.data.map(t => {
     return Object.assign({
-      editingCategory: state.edit.transactionCategories.has(t.id)
+      categoryGuess: categories[t.category.guess] || null,
+      categoryConfirmed: categories[t.category.confirmed] || null
     }, t);
-  })
+  });
+
   return {
     transactions,
-    categories: state.categories.data
+    categories
   };
 };
 
@@ -75,9 +81,6 @@ const mapDispatchToProps = dispatch => {
     },
     handleGuessCategoryForRow: rowId => {
       dispatch(actions.guessCategoryForRow(rowId));
-    },
-    handleEditCategoryForRow: rowId => {
-      dispatch(actions.editCategoryForRow(rowId));
     },
     handleDeleteRow: rowId => {
       dispatch(actions.deleteRow(rowId));

--- a/src/components/transactions/Category.js
+++ b/src/components/transactions/Category.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import CategoryGuessConfirm from './CategoryGuessConfirm';
+
+/**
+ * Showing a confirmed or guessed category.
+ */
+const Category = props => {
+  // 1. If the category has a guess, show that, as well as controls for
+  // confirming the guess.
+  // 2. If the category is confirmed, show an edit button
+  // 3. Otherwise show nothing.
+  if (props.categoryGuess) {
+    return <CategoryGuessConfirm
+      transactionId={props.transactionId}
+      categoryGuess={props.categoryGuess}
+      handleRowCategory={props.handleRowCategory}
+    />;
+  }
+
+  if (props.categoryConfirmed) {
+    return (
+      <span
+        className="cursor-pointer"
+        onClick={() => props.handleEditCategoryForRow(props.transactionId)}
+      >
+        {props.categoryConfirmed.name}
+        <FontAwesomeIcon icon="edit" className="ml-1" fixedWidth />
+      </span>
+    );
+  }
+
+  return null;
+};
+
+Category.propTypes = {
+  handleRowCategory: PropTypes.func.isRequired,
+  handleEditCategoryForRow: PropTypes.func.isRequired,
+  transactionId: PropTypes.string.isRequired,
+  categoryGuess: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }),
+  categoryConfirmed: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  })
+};
+
+export default Category;

--- a/src/components/transactions/CategoryGuessConfirm.js
+++ b/src/components/transactions/CategoryGuessConfirm.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+
+/**
+ * Controls for confirming or rejecting a category guess.
+ */
+const CategoryGuessConfirm = props => {
+  return (
+    <React.Fragment>
+      {props.categoryGuess.name}
+      <FontAwesomeIcon
+        icon="question-circle"
+        className="text-info" 
+        data-tip="This is a guess, confirm or edit it on the right"
+        fixedWidth
+      />
+      <button
+        type="button"
+        className="btn btn-outline-success btn-sm border-0"
+        onClick={() => props.handleRowCategory(props.transactionId, props.categoryGuess.id)}
+        aria-label="Confirm Guess"
+        data-tip="Confirm Guess"
+      >
+        <FontAwesomeIcon icon="thumbs-up" fixedWidth />
+      </button>
+      <button
+        type="button"
+        className="btn btn-outline-danger btn-sm border-0"
+        onClick={() => props.handleRowCategory(props.transactionId, '')}
+        aria-label="Reject guess"
+        data-tip="Reject guess"
+      >
+        <FontAwesomeIcon icon="thumbs-down" fixedWidth />
+      </button>
+    </React.Fragment>
+  );
+};
+
+CategoryGuessConfirm.propTypes = {
+  transactionId: PropTypes.string.isRequired,
+  categoryGuess: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }).isRequired,
+  handleRowCategory: PropTypes.func.isRequired
+};
+
+export default CategoryGuessConfirm;

--- a/src/components/transactions/CategorySelect.js
+++ b/src/components/transactions/CategorySelect.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+
+const customStyles = {
+  control: (base, state) => ({
+    ...base,
+    width: 150
+  })
+};
+
+/**
+ * A select list for choosing a category.
+ */
+const CategorySelect = props => {
+  const onChange = (option, action) => {
+    if (action.action === 'select-option') {
+      props.handleRowCategory(props.transactionId, option.value)
+    }
+  };
+
+  return (
+    <Select
+      value={props.selectedValue}
+      options={props.options}
+      onChange={onChange}
+      styles={customStyles}
+    />
+  );
+};
+
+CategorySelect.propTypes = {
+  handleRowCategory: PropTypes.func.isRequired,
+  transactionId: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired
+  })).isRequired,
+  categoryConfirmedId: PropTypes.string
+};
+
+export default CategorySelect;

--- a/src/components/transactions/RowCategorizer.js
+++ b/src/components/transactions/RowCategorizer.js
@@ -66,7 +66,6 @@ RowCategorizer.propTypes = {
       guess: PropTypes.string,
       confirmed: PropTypes.string
     }).isRequired,
-    editingCategory: PropTypes.bool.isRequired,
     categoryGuess: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired

--- a/src/components/transactions/RowCategorizer.js
+++ b/src/components/transactions/RowCategorizer.js
@@ -1,157 +1,85 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import Category from './Category';
+import CategorySelect from './CategorySelect';
 
-/**
- * Controls for confirming or rejecting a category guess.
- */
-const CategoryGuessConfirm = props => {
-  return (
-    <React.Fragment>
-      {props.categoryGuessName}
-      <FontAwesomeIcon
-        icon="question-circle"
-        className="text-info ml-1" 
-        data-tip="This is a guess, confirm or edit it on the right"
-      />
-      <button
-        type="button"
-        className="btn btn-outline-success btn-sm ml-1 border-0"
-        onClick={() => props.handleRowCategory(props.transactionId, props.categoryGuess)}
-        title="Confirm Guess"
-      >
-        <FontAwesomeIcon icon="thumbs-up" />
-      </button>
-      <button
-        type="button"
-        className="btn btn-outline-danger btn-sm border-0"
-        onClick={() => props.handleRowCategory(props.transactionId, '')}
-        title="Reject guess"
-      >
-        <FontAwesomeIcon icon="thumbs-down" />
-      </button>
-    </React.Fragment>
-  );
-};
+class RowCategorizer extends React.Component {
+  constructor(props) {
+    super(props);
 
-/**
- * Showing a confirmed or guessed category.
- */
-const Category = props => {
-  // 1. If the category has a guess, show that, as well as controls for
-  // confirming the guess.
-  // 2. If the category is confirmed, show an edit button
-  // 3. Otherwise show nothing.
-  if (props.transaction.category.guess) {
-    const categoryName = props.categories
-      .find(c => c.id === props.transaction.category.guess)
-      .name;
-    return <CategoryGuessConfirm
-      transactionId={props.transaction.id}
-      categoryGuess={props.transaction.category.guess}
-      categoryGuessName={categoryName}
-      handleRowCategory={props.handleRowCategory}
-    />;
+    this.state = {
+      editing: !props.transaction.categoryGuess &&
+        !props.transaction.categoryConfirmed
+    };
+
+    this.handleEditCategory = this.handleEditCategory.bind(this);
   }
 
-  if (props.transaction.category.confirmed) {
-    const categoryName = props.categories
-      .find(c => c.id === props.transaction.category.confirmed)
-      .name;
+  static getDerivedStateFromProps(props, state) {
+    if (state.editing &&
+      (props.transaction.categoryGuess || props.transaction.categoryConfirmed)) {
+      return { editing: false };
+    } else if (!state.editing && 
+     (!props.transaction.categoryGuess && !props.transaction.categoryConfirmed)) {
+      return { editing: true };
+    }
+    return null;
+  }
+
+  handleEditCategory() {
+    this.setState({ editing: true });
+  }
+
+  render() {
+    let categoryConfirmedAsOption = null;
+    if (this.state.editing && this.props.transaction.categoryConfirmed) {
+      categoryConfirmedAsOption = {
+        label: this.props.transaction.categoryConfirmed.name,
+        value: this.props.transaction.categoryConfirmed.id
+      };
+    }
+
     return (
-      <span
-        className="cursor-pointer"
-        onClick={() => props.handleEditCategoryForRow(props.transaction.id)}
-      >
-        {categoryName}
-        <FontAwesomeIcon icon="edit" className="ml-1" fixedWidth />
-      </span>
+      <React.Fragment>
+        {!this.state.editing && <Category
+          transactionId={this.props.transaction.id}
+          categoryGuess={this.props.transaction.categoryGuess}
+          categoryConfirmed={this.props.transaction.categoryConfirmed}
+          handleRowCategory={this.props.handleRowCategory}
+          handleEditCategoryForRow={this.handleEditCategory}
+        />}
+        {this.state.editing && <CategorySelect
+          transactionId={this.props.transaction.id}
+          selectedValue={categoryConfirmedAsOption}
+          options={this.props.categoryOptions}
+          handleRowCategory={this.props.handleRowCategory}
+        />}
+      </React.Fragment>
     );
   }
-
-  return null;
-};
-
-Category.propTypes = {
-  handleRowCategory: PropTypes.func.isRequired,
-  handleEditCategoryForRow: PropTypes.func.isRequired,
-  transaction: PropTypes.shape({
-    category: PropTypes.shape({
-      guess: PropTypes.string,
-      confirmed: PropTypes.string
-    }).isRequired
-  }).isRequired
-};
-
-/**
- * A select list for choosing a category.
- */
-const CategorySelect = props => {
-  return (
-    <select
-      className="form-control"
-      onChange={e => props.handleRowCategory(props.transaction.id, e.target.value)}
-      value={props.transaction.category.confirmed}
-    >
-      <option value=""></option>
-      {props.categories.map(category => {
-        return <option
-          key={`cat-${props.transaction.id}-${category.id}`}
-          value={category.id}
-        >
-          {category.name}
-        </option>
-      })}
-    </select>
-  );
-};
-
-CategorySelect.propTypes = {
-  handleRowCategory: PropTypes.func.isRequired,
-  transaction: PropTypes.shape({
-    id: PropTypes.string.isRequired
-  }).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
-  })).isRequired
-};
-
-const RowCategorizer = props => {
-  const showSelect = props.transaction.editingCategory ||
-    (!props.transaction.category.guess && !props.transaction.category.confirmed);
-
-  return (
-    <React.Fragment>
-      {!showSelect && <Category
-        transaction={props.transaction}
-        categories={props.categories}
-        handleRowCategory={props.handleRowCategory}
-        handleEditCategoryForRow={props.handleEditCategoryForRow}
-      />}
-      {showSelect && <CategorySelect
-        transaction={props.transaction}
-        categories={props.categories}
-        handleRowCategory={props.handleRowCategory}
-      />}
-    </React.Fragment>
-  );
-};
+}
 
 RowCategorizer.propTypes = {
   handleRowCategory: PropTypes.func.isRequired,
-  handleEditCategoryForRow: PropTypes.func.isRequired,
   transaction: PropTypes.shape({
     category: PropTypes.shape({
       guess: PropTypes.string,
       confirmed: PropTypes.string
     }).isRequired,
-    editingCategory: PropTypes.bool.isRequired
+    editingCategory: PropTypes.bool.isRequired,
+    categoryGuess: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    }),
+    categoryConfirmed: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    })
   }).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
-  })).isRequired
+  categoryOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired
+  })).isRequired,
 };
 
 export default RowCategorizer;

--- a/src/components/transactions/TransactionRow.js
+++ b/src/components/transactions/TransactionRow.js
@@ -24,7 +24,9 @@ const TransactionRow = props => {
     });
   }
 
-  const className = props.transaction.ignore ? 'table-warning' : '';
+  let className = '';
+  if (props.transaction.ignore) className = 'table-warning'
+  else if (props.transaction.categoryGuess) className = 'table-info';
 
   return (
     <tr className={className}>
@@ -43,8 +45,7 @@ const TransactionRow = props => {
       <td>
         <RowCategorizer
           transaction={props.transaction}
-          categories={props.categories}
-          handleEditCategoryForRow={props.handleEditCategoryForRow}
+          categoryOptions={props.categoryOptions}
           handleRowCategory={props.handleRowCategory}
         />
       </td>
@@ -71,17 +72,24 @@ const TransactionRow = props => {
 TransactionRow.propTypes = {
   transaction: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    ignore: PropTypes.bool
+    ignore: PropTypes.bool,
+    categoryGuess: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    }),
+    categoryConfirmed: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    })
   }).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
+  categoryOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired
   })).isRequired,
   showModal: PropTypes.func.isRequired,
   hideModal: PropTypes.func.isRequired,
   handleDeleteRow: PropTypes.func.isRequired,
   handleIgnoreRow: PropTypes.func.isRequired,
-  handleEditCategoryForRow: PropTypes.func.isRequired,
   handleRowCategory: PropTypes.func.isRequired
 };
 

--- a/src/components/transactions/TransactionTable.js
+++ b/src/components/transactions/TransactionTable.js
@@ -5,6 +5,17 @@ import TransactionRow from './TransactionRow';
 const TransactionTable = props => {
   const data = props.transactions;
 
+  // Map category options here to avoid having children re-map these for every
+  // row.
+  const categoryOptions = Object.values(props.categories)
+    .map(category => ({
+      label: category.parent ?
+        `${props.categories[category.parent].name} - ${category.name}` :
+        category.name,
+      value: category.id
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
   return (
     <div className="row">
       <div className="col">
@@ -24,9 +35,8 @@ const TransactionTable = props => {
               return <TransactionRow
                 key={`row-${transaction.id}`}
                 transaction={transaction}
-                categories={props.categories}
+                categoryOptions={categoryOptions}
                 handleRowCategory={props.handleRowCategory}
-                handleEditCategoryForRow={props.handleEditCategoryForRow}
                 handleDeleteRow={props.handleDeleteRow}
                 handleIgnoreRow={props.handleIgnoreRow}
                 showModal={props.showModal}
@@ -43,17 +53,21 @@ const TransactionTable = props => {
 TransactionTable.propTypes = {
   transactions: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired
+    description: PropTypes.string.isRequired,
+    categoryGuess: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    }),
+    categoryConfirmed: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired
+    })
   })).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
-  })).isRequired,
+  categories: PropTypes.object.isRequired,
   showModal: PropTypes.func.isRequired,
   hideModal: PropTypes.func.isRequired,
   handleIgnoreRow: PropTypes.func.isRequired,
   handleDeleteRow: PropTypes.func.isRequired,
-  handleEditCategoryForRow: PropTypes.func.isRequired,
   handleRowCategory: PropTypes.func.isRequired,
 };
 

--- a/src/data/categories.js
+++ b/src/data/categories.js
@@ -17,22 +17,24 @@ const defaultCategories = [
   // Staying alive
   foodAndDrink,
   { id: uuidv4(), name: 'Groceries', parent: foodAndDrink.id },
-  { id: uuidv4(), name: 'Eating Out', parent: foodAndDrink.id },
+  { id: uuidv4(), name: 'Restaurant/Fast-food', parent: foodAndDrink.id },
   { id: uuidv4(), name: 'Bar', parent: foodAndDrink.id },
+  { id: uuidv4(), name: 'Cafe', parent: foodAndDrink.id },
 
   // Getting around
   transportation,
   { id: uuidv4(), name: 'Public Transportation', parent: transportation.id },
-  { id: uuidv4(), name: 'Fuel', parent: transportation.id },
+  { id: uuidv4(), name: 'Fuel/Gas', parent: transportation.id },
   { id: uuidv4(), name: 'Car Loan/Leasing', parent: transportation.id },
   { id: uuidv4(), name: 'Car Maintenance', parent: transportation.id },
+  { id: uuidv4(), name: 'Car Insurance', parent: transportation.id },
 
   // Shelter
   home,
   { id: uuidv4(), name: 'Mortgage', parent: home.id },
   { id: uuidv4(), name: 'Rent', parent: home.id },
   { id: uuidv4(), name: 'Insurance', parent: home.id },
-  { id: uuidv4(), name: 'Utilities', parent: home.id },
+  { id: uuidv4(), name: 'Utilities/water/electricity', parent: home.id },
   { id: uuidv4(), name: 'Internet', parent: home.id },
 
   // Shopping

--- a/src/reducers/edit.js
+++ b/src/reducers/edit.js
@@ -2,30 +2,11 @@ import update from 'immutability-helper';
 import * as actions from '../actions';
 
 const initialEditor = {
-  transactionCategories: new Set(),
   dateSelect: {}
 };
 
 const editReducer = (state = initialEditor, action) => {
   switch (action.type) {
-    case actions.EDIT_CATEGORY_FOR_ROW:
-      let rowsToAdd = action.rowId;
-      if (!Array.isArray(rowsToAdd)) {
-        rowsToAdd = [rowsToAdd];
-      }
-      return update(state, {
-        transactionCategories: {
-          $add: rowsToAdd
-        }
-      });
-    case actions.GUESS_CATEGORY_FOR_ROW:
-    case actions.CATEGORIZE_ROW:
-      // Remove all editing categories when guessing and categorizing.
-      return update(state, {
-        transactionCategories: {
-          $remove: Array.from(state.transactionCategories)
-        }
-      });
     case actions.EDIT_DATES:
       return update(state, {
         dateSelect: {

--- a/src/reducers/edit.test.js
+++ b/src/reducers/edit.test.js
@@ -1,22 +1,6 @@
 import reducers from './index';
 import * as actions from '../actions';
 
-it('should add categories being edited', () => {
-  const state = reducers({}, actions.editCategoryForRow('a'));
-  expect(state.edit.transactionCategories.has('a')).toBeTruthy();
-  expect(state.edit.transactionCategories.has('b')).toBeFalsy();
-});
-
-it('should clear categories being edited', () => {
-  const state = reducers({
-    edit: {
-      transactionCategories: new Set(['a', 'b'])
-    }
-  }, actions.guessCategoryForRow('b'));
-
-  expect(state.edit.transactionCategories.size).toEqual(0);
-});
-
 it('should set the date selection for the given dates', () => {
   const state = reducers({
     edit: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,37 @@
 # yarn lockfile v1
 
 
+"@babel/helper-module-imports@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.32.tgz#8126fc024107c226879841b973677a4f4e510a03"
+  dependencies:
+    "@babel/types" "7.0.0-beta.32"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.32.tgz#c317d0ecc89297b80bbcb2f50608e31f6452a5ff"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
+"@emotion/hash@^0.6.2":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.3.tgz#0e7a5604626fc6c6d4ac4061a2f5ac80d50262a4"
+
+"@emotion/memoize@^0.6.1":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.2.tgz#138e00b332d519b4e307bded6159e5ba48aba3ae"
+
+"@emotion/stylis@^0.6.5":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.6.8.tgz#6ad4e8d32b19b440efa4481bbbcb98a8c12765bb"
+
+"@emotion/unitless@^0.6.2":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.3.tgz#65682e68a82701c70eefb38d7f941a2c0bfa90de"
+
 "@fortawesome/fontawesome-common-types@^0.1.3", "@fortawesome/fontawesome-common-types@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.4.tgz#1fbc66f0223646f23c5550c2c12e341078e2c262"
@@ -617,6 +648,22 @@ babel-plugin-dynamic-import-node@1.1.0:
     babel-template "^6.26.0"
     babel-types "^6.26.0"
 
+babel-plugin-emotion@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.1.2.tgz#e26b313fa0fecd0f2cc07b1e4ef05da167e4f740"
+  dependencies:
+    "@babel/helper-module-imports" "7.0.0-beta.32"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.6.5"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^1.0.0"
+
 babel-plugin-istanbul@^4.0.0:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
@@ -628,6 +675,12 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+
+babel-plugin-macros@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.2.1.tgz#7cc0f84735aa86f776b51860793a98928f43a7fa"
+  dependencies:
+    cosmiconfig "^4.0.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -649,7 +702,7 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
 
-babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
@@ -1782,12 +1835,32 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
+
 create-ecdh@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-emotion@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.1.3.tgz#a2e570415eb3e1ec7c42489ba55b2361baf0ed3f"
+  dependencies:
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.6.5"
+    "@emotion/unitless" "^0.6.2"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -2368,6 +2441,13 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
+emotion@^9.1.2:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.1.3.tgz#e9b3e897ba3d5c0aff5628b0008a8993fa9c0937"
+  dependencies:
+    babel-plugin-emotion "^9.1.2"
+    create-emotion "^9.1.3"
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -2438,7 +2518,7 @@ errno@^0.1.3, errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -3014,6 +3094,10 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -4370,7 +4454,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
@@ -4423,6 +4507,10 @@ jsesc@~0.5.0:
 json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -4649,7 +4737,7 @@ lodash.uniq@^4.5.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.1.1:
+lodash@^4.1.1, lodash@^4.2.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5045,6 +5133,12 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -5350,6 +5444,13 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse-passwd@^1.0.0:
   version "1.0.0"
@@ -6043,6 +6144,12 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-input-autosize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-is@^16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.1.tgz#ee66e6d8283224a83b3030e110056798488359ba"
@@ -6152,6 +6259,17 @@ react-scripts@1.1.4:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "^1.1.3"
+
+react-select@^2.0.0-beta.6:
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.0.0-beta.6.tgz#87ac27831f348cb9535dfd825534934adcfb7e97"
+  dependencies:
+    classnames "^2.2.5"
+    emotion "^9.1.2"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
+    react-transition-group "^2.2.1"
 
 react-smooth@1.0.0:
   version "1.0.0"
@@ -6531,6 +6649,10 @@ require-directory@^2.1.1:
 require-from-string@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
+require-from-string@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -7104,6 +7226,14 @@ style-loader@0.19.0:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -7276,6 +7406,10 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -7301,6 +7435,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 toposort@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
+
+touch@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-1.0.0.tgz#449cbe2dbae5a8c8038e30d71fa0ff464947c4de"
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"


### PR DESCRIPTION
This commit adds react-select to provide easier category selection.

Changes:
- Add react-select and use it for category selection.
- Remove category editing from global state and change over to React
  state.
- Optimize selection of categories for dropdown.
- Refactor some transaction components.
- Small tweaks to layout and color

Closes #19