### PR TITLE
Add pagination and sorting to transactions table

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@fortawesome/fontawesome-free-solid": "^5.0.10",
     "@fortawesome/react-fontawesome": "^0.0.18",
     "bayes": "^0.0.7",
-    "bootstrap": "^4.0.0",
+    "bootstrap": "4.1.1",
     "d3-array": "^1.2.1",
     "d3-collection": "^1.0.4",
     "downloadjs": "^1.4.7",

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { show, hide } from 'redux-modal';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import ReactTooltip from 'react-tooltip';
 import * as actions from '../actions';
 import Confirm from './modals/Confirm';
 import NoData from './NoData';
@@ -35,6 +35,7 @@ const Transactions = props => {
           </button>
         </div>
       </div>
+      <hr />
       <TransactionTable
         transactions={props.transactions}
         categories={props.categories}
@@ -45,7 +46,6 @@ const Transactions = props => {
         hideModal={props.hideModal}
       />
       <Confirm />
-      <ReactTooltip />
     </React.Fragment>
   );
 };
@@ -62,10 +62,12 @@ const mapStateToProps = state => {
   }, {});
 
   const transactions = state.transactions.data.map(t => {
-    return Object.assign({
+    return {
       categoryGuess: categories[t.category.guess] || null,
-      categoryConfirmed: categories[t.category.confirmed] || null
-    }, t);
+      categoryConfirmed: categories[t.category.confirmed] || null,
+      ...t,
+      date: moment(t.date)
+    };
   });
 
   return {

--- a/src/components/Transactions.test.js
+++ b/src/components/Transactions.test.js
@@ -64,7 +64,6 @@ describe('Transactions', () => {
     expect(container.find('table').length).toEqual(1);
 
     const row = container.find('tr').eq(1);
-    expect(row.find('td').eq(0).text()).toEqual('2018-01-01');
     expect(row.find('td').eq(1).text()).toEqual('test');
     expect(row.find('td').eq(2).text()).toEqual('1');
     expect(row.find('td').eq(3).text()).toEqual('2');

--- a/src/components/shared/Pagination.js
+++ b/src/components/shared/Pagination.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Pagination = props => {
+  const lastPage = Math.ceil(props.rowCount / props.pageSize);
+
+  const pages = [];
+  // If the current page is 3 or above, go two levels back, except if we're
+  // getting close to the final page, in which case we should go 3 or 4 back.
+  const pagesLeft = lastPage - props.page;
+  let minPage = props.page > 2 ? props.page - 2 : 1;
+  if (pagesLeft < 2) {
+    minPage -= (2 - pagesLeft);
+    if (minPage < 1) minPage = 1;
+  }
+
+  // The max page is determined from the min page more easily :-)
+  const maxPage = props.page + (minPage === 1 ? 4 : minPage === 2 ? 3 : 2);
+
+  // Now we can just run through them all.
+  for (let i = minPage; i <= maxPage && i <= lastPage; i++) {
+    if (pages.length === 5) break;
+    const paging = <li
+      key={`page-item-${i}`}
+      className={`page-item${i === props.page ? ' active': ''}`}
+    >
+      {i === props.page && 
+        <span className="page-link">
+          {i}
+          <span className="sr-only">(current)</span>
+        </span>
+      }
+      {i !== props.page &&
+        <button
+          className="page-link"
+          onClick={() => props.handlePageChange(i)}
+        >
+          {i}
+        </button>
+      }
+    </li>
+    pages.push(paging)
+  }
+
+  return (
+    <nav className="d-inline-flex align-items-center">
+      <ul className="pagination mr-3 mb-0">
+        <li className={`page-item${props.page === 1 ? ' disabled' : ''}`}>
+          <button
+            className="page-link"
+            onClick={() => props.handlePageChange(props.page - 1)}
+          >
+            Previous
+          </button>
+        </li>
+        {pages}
+        <li className={`page-item${props.page === lastPage ? ' disabled' : ''}`}>
+          <button
+            className="page-link"
+            onClick={() => props.handlePageChange(props.page + 1)}
+          >
+            Next
+          </button>
+        </li>
+      </ul>
+      <span className="text-nowrap px-2">
+        Per Page:
+      </span>
+      <select
+        id="page-size"
+        className="form-control"
+        value={props.pageSize}
+        onChange={e => props.handlePageSizeChange(Number(e.target.value))}
+      >
+        <option value="10">10</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+      </select>
+    </nav>
+  );
+};
+
+Pagination.propTypes = {
+  page: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  rowCount: PropTypes.number.isRequired,
+  handlePageChange: PropTypes.func.isRequired,
+  handlePageSizeChange: PropTypes.func.isRequired
+};
+
+export default Pagination;

--- a/src/components/transactions/SortHeader.js
+++ b/src/components/transactions/SortHeader.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+
+const SortIndicator = props => {
+  const icon = !props.active ? 'sort' : props.ascending ? 'sort-up' : 'sort-down';
+  return (
+    <span className="px-1">
+      <FontAwesomeIcon icon={icon} />
+    </span>
+  );
+};
+
+SortIndicator.propTypes = {
+  ascending: PropTypes.bool.isRequired,
+  active: PropTypes.bool.isRequired
+};
+
+const SortHeader = props => {
+  return (
+    <th
+      scope="col"
+      className="text-nowrap"
+      onClick={() => props.handleSortChange(props.sortKey, !props.sortAscending)}
+    >
+      {props.label}
+      <SortIndicator
+        ascending={props.sortAscending}
+        active={props.sortKey === props.activeSortKey}
+      />
+    </th>
+  );
+};
+
+SortHeader.propTypes = {
+  label: PropTypes.string.isRequired,
+  sortKey: PropTypes.string.isRequired,
+  activeSortKey: PropTypes.string.isRequired,
+  sortAscending: PropTypes.bool.isRequired,
+  handleSortChange: PropTypes.func.isRequired
+};
+
+export default SortHeader;

--- a/src/components/transactions/TransactionRow.js
+++ b/src/components/transactions/TransactionRow.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import Confirm from '../modals/Confirm';
 import RowCategorizer from './RowCategorizer';
@@ -30,8 +31,8 @@ const TransactionRow = props => {
 
   return (
     <tr className={className}>
-      <td>
-        {props.transaction.date}
+      <td className="text-nowrap">
+        {props.transaction.date.format('L')}
       </td>
       <td>
         {props.transaction.description}
@@ -42,14 +43,14 @@ const TransactionRow = props => {
       <td>
         {props.transaction.total}
       </td>
-      <td>
+      <td className="text-nowrap">
         <RowCategorizer
           transaction={props.transaction}
           categoryOptions={props.categoryOptions}
           handleRowCategory={props.handleRowCategory}
         />
       </td>
-      <td>
+      <td className="text-nowrap">
         <div className="d-inline-flex">
           <IgnoreTransaction
             transactionId={props.transaction.id}
@@ -72,6 +73,7 @@ const TransactionRow = props => {
 TransactionRow.propTypes = {
   transaction: PropTypes.shape({
     id: PropTypes.string.isRequired,
+    date: PropTypes.instanceOf(moment),
     ignore: PropTypes.bool,
     categoryGuess: PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/src/components/transactions/TransactionTable.test.js
+++ b/src/components/transactions/TransactionTable.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import moment from 'moment';
+import configureStore from 'redux-mock-store';
+import { MemoryRouter } from 'react-router-dom';
+import { shallow, mount } from 'enzyme';
+import TransactionTable from './TransactionTable';
+
+jest.mock('redux-modal', () => {
+  return {
+    connectModal: () => () => () => <span>YOLO</span>
+  };
+});
+
+const transactions = [
+  // Note that this is unsorted for dates.
+  {
+    id: 'a',
+    date: moment('2018-01-02').locale('sv-SE'),
+    amount: 1,
+    description: 'test',
+    total: 3,
+  },
+  {
+    id: 'b',
+    date: moment('2018-01-01').locale('sv-SE'),
+    amount: 2,
+    description: 'test',
+    total: 2,
+  }
+];
+
+const categories = {
+  a: {
+    id: 'a',
+    name: 'Food'
+  },
+  b: {
+    id: 'b',
+    name: 'Travel'
+  }
+};
+
+const defaultProps = {
+  transactions,
+  categories,
+  showModal: jest.fn(),
+  hideModal: jest.fn(),
+  handleIgnoreRow: jest.fn(),
+  handleDeleteRow: jest.fn(),
+  handleRowCategory: jest.fn()
+};
+
+it('should show transaction rows', () => {
+  const container = shallow(<TransactionTable {...defaultProps} />);
+  expect(container.find('TransactionRow').length).toEqual(2);
+  const rendered = container.render();
+  expect(rendered.find('tbody > tr').eq(0).find('td').first().text()).toEqual('2018-01-01');
+  expect(rendered.find('tbody > tr').eq(1).find('td').first().text()).toEqual('2018-01-02');
+});
+
+it('should show less rows when paginating', () => {
+  const container = shallow(
+    <TransactionTable
+      {...defaultProps}
+    />
+  );
+  container.instance().handlePageSizeChange(1);
+  container.update();
+  expect(container.find('TransactionRow').length).toEqual(1);
+  const rendered = container.render();
+  expect(rendered.find('td').first().text()).toEqual('2018-01-01');
+  expect(rendered.find('.page-item').first().hasClass('disabled')).toEqual(true);
+  expect(rendered.find('.page-item').last().hasClass('disabled')).toEqual(false);
+});
+
+it('should show page two', () => {
+  const container = shallow(
+    <TransactionTable
+      {...defaultProps}
+    />
+  );
+  container.instance().handlePageSizeChange(1);
+  container.instance().handlePageChange(2);
+  container.update();
+  expect(container.find('TransactionRow').length).toEqual(1);
+  const rendered = container.render();
+  expect(rendered.find('td').first().text()).toEqual('2018-01-02');
+  expect(rendered.find('.page-item').first().hasClass('disabled')).toEqual(false);
+  expect(rendered.find('.page-item').last().hasClass('disabled')).toEqual(true);
+});
+
+it('should sort descending', () => {
+  const container = shallow(
+    <TransactionTable
+      {...defaultProps}
+    />
+  );
+  container.instance().handleSortChange('date', false);
+  container.update();
+  const rendered = container.render();
+
+  expect(rendered.find('tbody > tr').first().find('td').first().text()).toEqual('2018-01-02');
+  expect(rendered.find('tbody > tr').last().find('td').first().text()).toEqual('2018-01-01');
+});
+
+it('should change page if page size makes a page no longer exist', () => {
+  const container = shallow(
+    <TransactionTable
+      {...defaultProps}
+    />
+  );
+  container.instance().handlePageSizeChange(1);
+  container.instance().handlePageChange(2);
+  container.instance().handlePageSizeChange(10);
+  container.update();
+  expect(container.find('TransactionRow').length).toEqual(2);
+  const rendered = container.render();
+  expect(rendered.find('td').first().text()).toEqual('2018-01-01');
+});

--- a/src/configureFa.js
+++ b/src/configureFa.js
@@ -1,0 +1,38 @@
+import fontawesome from '@fortawesome/fontawesome';
+import faUpload from '@fortawesome/fontawesome-free-solid/faUpload';
+import faChartBar from '@fortawesome/fontawesome-free-solid/faChartBar';
+import faTable from '@fortawesome/fontawesome-free-solid/faTable';
+import faDatabase from '@fortawesome/fontawesome-free-solid/faDatabase';
+import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
+import faEdit from '@fortawesome/fontawesome-free-solid/faEdit';
+import faLightbulb from '@fortawesome/fontawesome-free-solid/faLightbulb';
+import faDownload from '@fortawesome/fontawesome-free-solid/faDownload';
+import faThumbsDown from '@fortawesome/fontawesome-free-solid/faThumbsDown';
+import faThumbsUp from '@fortawesome/fontawesome-free-solid/faThumbsUp';
+import faTrashAlt from '@fortawesome/fontawesome-free-solid/faTrashAlt';
+import faPlus from '@fortawesome/fontawesome-free-solid/faPlus';
+import faBan from '@fortawesome/fontawesome-free-solid/faBan';
+import faSort from '@fortawesome/fontawesome-free-solid/faSort';
+import faSortUp from '@fortawesome/fontawesome-free-solid/faSortUp';
+import faSortDown from '@fortawesome/fontawesome-free-solid/faSortDown';
+
+export default function configureFa() {
+  fontawesome.library.add(
+    faUpload,
+    faChartBar,
+    faTable,
+    faDatabase,
+    faQuestionCircle,
+    faEdit,
+    faLightbulb,
+    faDownload,
+    faThumbsUp,
+    faThumbsDown,
+    faTrashAlt,
+    faPlus,
+    faBan,
+    faSort,
+    faSortUp,
+    faSortDown
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,47 +5,12 @@ import { PersistGate } from 'redux-persist/integration/react';
 import './css/index.css';
 import App from './components/App';
 import configureStore from './configureStore';
+import configureFa from './configureFa';
 import registerServiceWorker from './registerServiceWorker';
 
 import 'bootstrap/dist/css/bootstrap.css'; // Makes sure bootstrap is always available.
 
-// Build the fontawesome library
-import fontawesome from '@fortawesome/fontawesome';
-import faUpload from '@fortawesome/fontawesome-free-solid/faUpload';
-import faChartBar from '@fortawesome/fontawesome-free-solid/faChartBar';
-import faTable from '@fortawesome/fontawesome-free-solid/faTable';
-import faDatabase from '@fortawesome/fontawesome-free-solid/faDatabase';
-import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
-import faEdit from '@fortawesome/fontawesome-free-solid/faEdit';
-import faLightbulb from '@fortawesome/fontawesome-free-solid/faLightbulb';
-import faDownload from '@fortawesome/fontawesome-free-solid/faDownload';
-import faThumbsDown from '@fortawesome/fontawesome-free-solid/faThumbsDown';
-import faThumbsUp from '@fortawesome/fontawesome-free-solid/faThumbsUp';
-import faTrashAlt from '@fortawesome/fontawesome-free-solid/faTrashAlt';
-import faPlus from '@fortawesome/fontawesome-free-solid/faPlus';
-import faBan from '@fortawesome/fontawesome-free-solid/faBan';
-import faSort from '@fortawesome/fontawesome-free-solid/faSort';
-import faSortUp from '@fortawesome/fontawesome-free-solid/faSortUp';
-import faSortDown from '@fortawesome/fontawesome-free-solid/faSortDown';
-fontawesome.library.add(
-  faUpload,
-  faChartBar,
-  faTable,
-  faDatabase,
-  faQuestionCircle,
-  faEdit,
-  faLightbulb,
-  faDownload,
-  faThumbsUp,
-  faThumbsDown,
-  faTrashAlt,
-  faPlus,
-  faBan,
-  faSort,
-  faSortUp,
-  faSortDown
-);
-
+configureFa();
 const { store, persistor } = configureStore({});
 
 ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,9 @@ import faThumbsUp from '@fortawesome/fontawesome-free-solid/faThumbsUp';
 import faTrashAlt from '@fortawesome/fontawesome-free-solid/faTrashAlt';
 import faPlus from '@fortawesome/fontawesome-free-solid/faPlus';
 import faBan from '@fortawesome/fontawesome-free-solid/faBan';
+import faSort from '@fortawesome/fontawesome-free-solid/faSort';
+import faSortUp from '@fortawesome/fontawesome-free-solid/faSortUp';
+import faSortDown from '@fortawesome/fontawesome-free-solid/faSortDown';
 fontawesome.library.add(
   faUpload,
   faChartBar,
@@ -37,7 +40,10 @@ fontawesome.library.add(
   faThumbsDown,
   faTrashAlt,
   faPlus,
-  faBan
+  faBan,
+  faSort,
+  faSortUp,
+  faSortDown
 );
 
 const { store, persistor } = configureStore({});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,6 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import configureFa from './configureFa';
 
+configureFa();
 configure({ adapter: new Adapter() });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,9 +1214,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.0.tgz#110b05c31a236d56dbc9adcda6dd16f53738a28a"
+bootstrap@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.1.tgz#3aec85000fa619085da8d2e4983dfd67cf2114cb"
 
 bowser@^1.7.3:
   version "1.9.3"


### PR DESCRIPTION
This commit adds pagination and sorting to the transaction table to
avoid showing a very long table.

Changes:
- Add pagination component.
- Use pagination component on transaction table.
- Add sorting to transaction table headers.
- Adjust text overflow for columns in transaction table.

Also updates Bootstrap to 4.1.1.

Closes #20