### PR TITLE
Add functionality for guessing all categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "d3-collection": "^1.0.4",
     "downloadjs": "^1.4.7",
     "immutability-helper": "^2.6.6",
+    "lodash": "^4.17.10",
     "moment": "^2.22.0",
     "papaparse": "^4.3.7",
     "prop-types": "^15.6.1",

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -15,24 +15,27 @@ const Transactions = props => {
 
   return (
     <React.Fragment>
-      <div className="row">
-        <div className="col">
+      <div className="row align-items-center">
+        <div className="col-auto">
           <Link to="/transaction/upload" className="btn btn-outline-primary">
             <FontAwesomeIcon icon="upload" className="mr-1" fixedWidth />
             Add More Transactions
           </Link>
           <button
             className="btn btn-outline-secondary ml-2"
-            onClick={() => {
-              const unconfirmedIds = props.transactions
-                .filter(t => !t.category.confirmed && !t.ignore)
-                .map(t => t.id);
-              props.handleGuessCategoryForRow(unconfirmedIds);
-            }}
+            onClick={() => props.handleGuessCategories()}
           >
             <FontAwesomeIcon icon="lightbulb" className="mr-1" fixedWidth />
             Guess missing categories
           </button>
+        </div>
+        <div className="col-auto status">
+          {props.isCategoryGuessing &&
+            <span>
+              Guessing categories...
+              <FontAwesomeIcon icon="spinner" className="ml-1" pulse />
+            </span>
+          }
         </div>
       </div>
       <hr />
@@ -52,7 +55,8 @@ const Transactions = props => {
 
 Transactions.propTypes = {
   transactions: PropTypes.arrayOf(PropTypes.object).isRequired,
-  categories: PropTypes.object.isRequired
+  categories: PropTypes.object.isRequired,
+  isCategoryGuessing: PropTypes.bool.isRequired
 }
 
 const mapStateToProps = state => {
@@ -72,17 +76,19 @@ const mapStateToProps = state => {
 
   return {
     transactions,
-    categories
+    categories,
+    isCategoryGuessing: state.app.isCategoryGuessing
   };
 };
 
 const mapDispatchToProps = dispatch => {
   return {
-    handleRowCategory: (rowId, category) => {
-      dispatch(actions.categorizeRow(rowId, category));
+    handleRowCategory: (rowId, categoryId) => {
+      dispatch(actions.categorizeRow(rowId, categoryId));
+      if (categoryId) dispatch(actions.guessAllCategories());
     },
-    handleGuessCategoryForRow: rowId => {
-      dispatch(actions.guessCategoryForRow(rowId));
+    handleGuessCategories: () => {
+      dispatch(actions.guessAllCategories())
     },
     handleDeleteRow: rowId => {
       dispatch(actions.deleteRow(rowId));

--- a/src/components/Transactions.test.js
+++ b/src/components/Transactions.test.js
@@ -15,6 +15,9 @@ describe('Transactions', () => {
 
   it('should render nothing when there are no transactions', () => {
     const store = mockStore({
+      app: {
+        isCategoryGuessing: false,
+      },
       transactions: {
         data: []
       },
@@ -33,8 +36,8 @@ describe('Transactions', () => {
 
   it('should render a table of transactions', () => {
     const store = mockStore({
-      edit: {
-        transactionCategories: new Set()
+      app: {
+        isCategoryGuessing: false,
       },
       transactions: {
         data: [
@@ -72,8 +75,8 @@ describe('Transactions', () => {
 
   it('should show guess confirm and edit buttons', () => {
     const store = mockStore({
-      edit: {
-        transactionCategories: new Set()
+      app: {
+        isCategoryGuessing: false,
       },
       transactions: {
         data: [
@@ -104,5 +107,38 @@ describe('Transactions', () => {
     const categoryCol = container.find('tr').eq(1).find('td').eq(4);
     expect(categoryCol.find('svg').length).toEqual(3);
     expect(categoryCol.text()).toEqual('Travel');
+  });
+
+  it('should render a spinner when guessing categories', () => {
+    const store = mockStore({
+      app: {
+        isCategoryGuessing: true,
+      },
+      transactions: {
+        data: [
+          {
+            id: 'abcd',
+            date: '2018-01-01',
+            amount: 1,
+            description: 'test',
+            total: 2,
+            category: {
+              guess: 'travel',
+              confirmed: ''
+            }
+          }
+        ]
+      },
+      categories: {
+        data: [{ id: 'travel', name: 'Travel' }]
+      }
+    });
+
+    const container = shallow(
+      <MemoryRouter>
+        <Transactions store={store} />
+      </MemoryRouter>
+    );
+    expect(container.render().find('.status').text()).toEqual('Guessing categories...');
   });
 });

--- a/src/components/transactions/CategoryGuessConfirm.js
+++ b/src/components/transactions/CategoryGuessConfirm.js
@@ -27,7 +27,7 @@ const CategoryGuessConfirm = props => {
       <span className="mx-1">{props.categoryGuess.name}</span>
       <FontAwesomeIcon
         icon="question-circle"
-        className="text-info mx-1"
+        className="text-info"
         data-tip="This is a guess, confirm or reject with the thumbs up or down on the left."
         fixedWidth
       />

--- a/src/components/transactions/TransactionTable.js
+++ b/src/components/transactions/TransactionTable.js
@@ -109,7 +109,7 @@ class TransactionTable extends React.Component {
         </div>
         <div className="row">
           <div className="col">
-            <table className="table table-striped table-responsive mt-3">
+            <table className="table table-striped table-responsive-md mt-3">
               <thead className="thead-dark">
                 <tr>
                   <SortHeader

--- a/src/configureFa.js
+++ b/src/configureFa.js
@@ -15,6 +15,7 @@ import faBan from '@fortawesome/fontawesome-free-solid/faBan';
 import faSort from '@fortawesome/fontawesome-free-solid/faSort';
 import faSortUp from '@fortawesome/fontawesome-free-solid/faSortUp';
 import faSortDown from '@fortawesome/fontawesome-free-solid/faSortDown';
+import faSpinner from '@fortawesome/fontawesome-free-solid/faSpinner';
 
 export default function configureFa() {
   fontawesome.library.add(
@@ -33,6 +34,7 @@ export default function configureFa() {
     faBan,
     faSort,
     faSortUp,
-    faSortDown
+    faSortDown,
+    faSpinner
   );
 };

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -3,6 +3,7 @@ import * as actions from '../actions';
 
 const initialApp = {
   isParsing: false,
+  isCategoryGuessing: false,
   storage: {
     localStorage: false
   }
@@ -30,6 +31,14 @@ const appReducer = (state = initialApp, action) => {
       if (!action.newState.app) return state;
       return update(state, {
         $set: action.newState.app
+      });
+    case actions.START_GUESS_ALL_CATEGORIES:
+      return update(state, {
+        isCategoryGuessing: { $set: true }
+      });
+    case actions.END_GUESS_ALL_CATEGORIES:
+      return update(state, {
+        isCategoryGuessing: { $set: false }
       });
     default:
       return state;

--- a/src/reducers/app.test.js
+++ b/src/reducers/app.test.js
@@ -7,6 +7,7 @@ it('should set default data', () => {
   const state = reducers({}, { type: 'NOOP' });
   expect(state.app).toEqual({
     isParsing: false,
+    isCategoryGuessing: false,
     storage: {
       localStorage: false 
     },
@@ -30,4 +31,12 @@ it('should handle the toggle persist action', () => {
 it('should set parsing to false on parse transaction ending', () => {
   const state = reducers({ app: { isParsing: true } }, actions.parseTransactionsEnd(null, [['2018-04-06', 'test row', 123, 456]]));
   expect(state.app.isParsing).toEqual(false);
+});
+
+it('should handle the guess start action', () => {
+  expect(reducers({}, actions.startGuessAllCategories()).app.isCategoryGuessing).toEqual(true);
+});
+
+it('should handle the guess end action', () => {
+  expect(reducers({ app: { isCategoryGuessing: true } }, actions.endGuessAllCategories()).app.isCategoryGuessing).toEqual(false);
 });

--- a/src/util.js
+++ b/src/util.js
@@ -81,3 +81,7 @@ export const createTestData = () => {
 
   return transactions;
 };
+
+export const sleep = timeToSleep => {
+  return new Promise(resolve => setTimeout(resolve, timeToSleep));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,7 +4737,7 @@ lodash.uniq@^4.5.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.1.1, lodash@^4.2.0:
+lodash@^4.1.1, lodash@^4.17.10, lodash@^4.2.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
This commit adds a new asynchronous action that can re-guess all
categories in chunks. The transaction list is changed such that
categories are re-guessed every time a new category is confirmed.