### PR TITLE
Fix last page when showing only uncategorized

### DIFF
--- a/src/components/transactions/TransactionTable.js
+++ b/src/components/transactions/TransactionTable.js
@@ -48,7 +48,6 @@ class TransactionTable extends React.Component {
     // Only called when receiving new props or on the first render. So this is
     // where we should just set all the raw transactions into local state so we
     // can easier sort, filter, etc. later
-    console.log('deriving');
     const data = [].concat(props.transactions);
     const dataView = sortData(
       filterData(data, state.showOnlyUncategorized),


### PR DESCRIPTION
This commit fixes #29 by using local state for storing transactions
while viewing the transactions table.

Rendering of the transaction list is also slightly optimized by only
using filtering and sorting during state updates and not during every
render.